### PR TITLE
fix(kown_host) allowed public key type values

### DIFF
--- a/bitbucket/resource_pipeline_ssh_known_host.go
+++ b/bitbucket/resource_pipeline_ssh_known_host.go
@@ -45,7 +45,7 @@ func resourcePipelineSshKnownHost() *schema.Resource {
 						"key_type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"Ed25519", "ECDSA", "RSA", "DSA"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"ssh-ed25519", "ecdsa-sha2-nistp256", "ssh-rsa", "ssh-dss"}, false),
 						},
 						"key": {
 							Type:     schema.TypeString,

--- a/bitbucket/resource_pipeline_ssh_known_host_test.go
+++ b/bitbucket/resource_pipeline_ssh_known_host_test.go
@@ -40,7 +40,7 @@ func TestAccBitbucketPipelineSshKnownHost_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "repository", "bitbucket_repository.test", "name"),
 					resource.TestCheckResourceAttr(resourceName, "hostname", "example.com"),
 					resource.TestCheckResourceAttr(resourceName, "public_key.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "public_key.0.key_type", "RSA"),
+					resource.TestCheckResourceAttr(resourceName, "public_key.0.key_type", "ssh-rsa"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key.0.md5_fingerprint"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key.0.sha256_fingerprint"),
 				),
@@ -57,7 +57,7 @@ func TestAccBitbucketPipelineSshKnownHost_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "repository", "bitbucket_repository.test", "name"),
 					resource.TestCheckResourceAttr(resourceName, "hostname", "example2.com"),
 					resource.TestCheckResourceAttr(resourceName, "public_key.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "public_key.0.key_type", "RSA"),
+					resource.TestCheckResourceAttr(resourceName, "public_key.0.key_type", "ssh-rsa"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key.0.md5_fingerprint"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key.0.sha256_fingerprint"),
 				),
@@ -120,7 +120,7 @@ resource "bitbucket_pipeline_ssh_known_host" "test" {
   hostname   = %[4]q
 
   public_key {
-    key_type = "RSA" 
+    key_type = "ssh-rsa" 
     key      = base64encode(%[3]q)
   }
 }

--- a/docs/resources/pipeline_ssh_known_host.md
+++ b/docs/resources/pipeline_ssh_known_host.md
@@ -21,7 +21,7 @@ resource "bitbucket_pipeline_ssh_known_host" "test" {
   hostname   = "example.com"
 
   public_key {
-    key_type = "Ed25519" 
+    key_type = "ssh-ed25519" 
     key      = base64encode("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKqP3Cr632C2dNhhgKVcon4ldUSAeKiku2yP9O9/bDtY")
   }
 }
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 ### Public Key
 
-* `key_type` - The type of the public key. Valid values are `Ed25519`, `ECDSA`, `RSA`, and `DSA`.
+* `key_type` - The type of the public key. Valid values are `ssh-ed25519`, `ecdsa-sha2-nistp256`, `ssh-rsa`, and `ssh-dss`.
 * `key` - The base64 encoded public key.
 
 ## Attributes Reference


### PR DESCRIPTION
This PR fixes the input validation for the `public_key.key_type` to work with values Bitbucket actually use for their known host entities.

The values have been retrieved by using the `/pipelines_config/ssh/known_hosts/?pagelen=100` endpoint. Where the added known host is tested with an correct SSH pipeline connection.

---
Fixes #70 