### PR TITLE
docs(know_host) update `hostname` and `public_key.key` to the correct…

### DIFF
--- a/bitbucket/utils.go
+++ b/bitbucket/utils.go
@@ -31,6 +31,15 @@ func RandSSHKeyPairSize(keySize int, comment string) (string, string, error) {
 	return fmt.Sprintf("%s %s", keyMaterial, comment), privateKeyPEM, nil
 }
 
+func RandPlainSSHKeyPairSize(keySize int) (string, error) {
+	privateKey, _, err := RandSSHKeyPairSize(keySize, "")
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Split(privateKey, " ")[1], nil
+}
+
 func genPrivateKey(keySize int) (*rsa.PrivateKey, string, error) {
 	privateKey, err := rsa.GenerateKey(crand.Reader, keySize)
 	if err != nil {

--- a/docs/resources/pipeline_ssh_known_host.md
+++ b/docs/resources/pipeline_ssh_known_host.md
@@ -18,11 +18,11 @@ This allows you to manage your Pipeline Ssh Known Hosts for a repository.
 resource "bitbucket_pipeline_ssh_known_host" "test" {
   workspace  = "example"
   repository = bitbucket_repository.test.name
-  hostname   = "example.com"
+  hostname   = "[example.com]:22"
 
   public_key {
     key_type = "ssh-ed25519" 
-    key      = base64encode("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKqP3Cr632C2dNhhgKVcon4ldUSAeKiku2yP9O9/bDtY")
+    key      = "AAAAC3NzaC1lZDI1NTE5AAAAIKqP3Cr632C2dNhhgKVcon4ldUSAeKiku2yP9O9/bDtY"
   }
 }
 ```
@@ -39,7 +39,7 @@ The following arguments are supported:
 ### Public Key
 
 * `key_type` - The type of the public key. Valid values are `ssh-ed25519`, `ecdsa-sha2-nistp256`, `ssh-rsa`, and `ssh-dss`.
-* `key` - The base64 encoded public key.
+* `key` - The plain public key.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR fixes the `hostname` and the `public_key.key` syntax to conform to the original entity definition.

The values have been retrieved by using the `/pipelines_config/ssh/known_hosts/?pagelen=100` endpoint. Where the added known host is tested with a correct SSH pipeline connection.

**Test result**
```
=== RUN   TestAccBitbucketPipelineSshKnownHost_basic
--- PASS: TestAccBitbucketPipelineSshKnownHost_basic (13.17s)
PASS
```

---

fixes #76