### PR TITLE
Add missing email_forwarding_disabled property to groups data lookup

### DIFF
--- a/bitbucket/data_groups.go
+++ b/bitbucket/data_groups.go
@@ -39,6 +39,10 @@ func dataGroups() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"email_forwarding_disabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Missing attribute causes the `groups` attribute to be empty:

```
2022-08-23T15:09:28.653+1200 [INFO]  provider.terraform-provider-bitbucket_v2.20.0: 2022/08/23 15:09:28 [DEBUG] User Group Response Decoded: &bitbucket.UserGroup{Name:"Administrators", Slug:"administrators", AutoAdd:true, Permission:"admin", EmailForwardingDisabled:false}: timestamp=2022-08-23T15:09:28.650+1200
2022-08-23T15:09:28.653+1200 [INFO]  provider.terraform-provider-bitbucket_v2.20.0: 2022/08/23 15:09:28 [ERROR] setting state: Invalid address to set: []string{"groups", "0", "email_forwarding_disabled"}: timestamp=2022-08-23T15:09:28.650+1200
```