### PR TITLE
docs(user): use uuid instead of account_id

### DIFF
--- a/docs/data-sources/current_user.md
+++ b/docs/data-sources/current_user.md
@@ -3,7 +3,7 @@ layout: "bitbucket"
 page_title: "Bitbucket: bitbucket_current_user"
 sidebar_current: "docs-bitbucket-data-current-user"
 description: |-
-  Provides a data for the current Bitbucket user
+  Provides data for the current Bitbucket user
 ---
 
 # bitbucket\_user
@@ -15,7 +15,7 @@ OAuth2 Scopes: `account`
 ## Example Usage
 
 ```hcl
-data "bitbucket_currnet_user" "example" {}
+data "bitbucket_current_user" "example" {}
 ```
 
 ## Argument Reference

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -3,7 +3,7 @@ layout: "bitbucket"
 page_title: "Bitbucket: bitbucket_user"
 sidebar_current: "docs-bitbucket-data-user"
 description: |-
-  Provides a data for a Bitbucket user
+  Provides data for a Bitbucket user
 ---
 
 # bitbucket\_user
@@ -14,7 +14,7 @@ Provides a way to fetch data on a user.
 
 ```hcl
 data "bitbucket_user" "reviewer" {
-  account_id = "gob"
+  uuid = "{account UUID}"
 }
 ```
 

--- a/docs/resources/default_reviewers.md
+++ b/docs/resources/default_reviewers.md
@@ -16,7 +16,7 @@ OAuth2 Scopes: `pullrequest` and `repository:admin`
 
 ```hcl
 data "bitbucket_user" "reviewer" {
-  account_id = "gob"
+  uuid = "{account UUID}"
 }
 
 resource "bitbucket_default_reviewers" "infrastructure" {

--- a/docs/resources/project_default_reviewers.md
+++ b/docs/resources/project_default_reviewers.md
@@ -16,7 +16,7 @@ OAuth2 Scopes: `project:admin`
 
 ```hcl
 data "bitbucket_user" "reviewer" {
-  account_id = "gob"
+  uuid = "{account UUID}"
 }
 
 resource "bitbucket_project_default_reviewers" "infrastructure" {


### PR DESCRIPTION
This replaces the removed `"account_id"` property with `"uuid"`. I also fixed some smaller grammar issues in the user docs.