### PR TITLE
docs(project-branching-model): fix small typo in example

### DIFF
--- a/docs/resources/project_branching_model.md
+++ b/docs/resources/project_branching_model.md
@@ -25,7 +25,7 @@ resource "bitbucket_project" "example" {
 
 resource "bitbucket_project_branching_model" "example" {
   workspace = "example"
-  pronect   = bitbucket_project.example.key
+  project   = bitbucket_project.example.key
 
   development {
     use_mainbranch = true


### PR DESCRIPTION
This fixes a small but essential typo in the project-branching-model documentation.