### PR TITLE
fix(repository): set actual slug property instead of the repository name

### DIFF
--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -270,7 +270,7 @@ func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("has_wiki", repoRes.HasWiki)
 	d.Set("has_issues", repoRes.HasIssues)
 	d.Set("name", repoRes.Name)
-	d.Set("slug", repoRes.Name)
+	d.Set("slug", repoRes.Slug)
 	d.Set("language", repoRes.Language)
 	d.Set("fork_policy", repoRes.ForkPolicy)
 	// d.Set("website", repoRes.Website)

--- a/bitbucket/resource_repository_test.go
+++ b/bitbucket/resource_repository_test.go
@@ -107,6 +107,34 @@ func TestAccBitbucketRepository_avatar(t *testing.T) {
 	})
 }
 
+func TestAccBitbucketRepository_slug(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-test")
+	rSlug := acctest.RandomWithPrefix("tf-test")
+	testUser := os.Getenv("BITBUCKET_TEAM")
+	resourceName := "bitbucket_repository.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBitbucketRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBitbucketRepoSlugConfig(testUser, rName, rSlug),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBitbucketRepositoryExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "slug", rSlug),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccBitbucketRepoConfig(testUser, rName string) string {
 	return fmt.Sprintf(`
 resource "bitbucket_repository" "test" {
@@ -147,14 +175,14 @@ resource "bitbucket_repository" "test" {
 `, testUser, rName)
 }
 
-func testAccBitbucketRepoSlugConfig(testUser, rName, rName2 string) string {
+func testAccBitbucketRepoSlugConfig(testUser, rName, rSlug string) string {
 	return fmt.Sprintf(`
 resource "bitbucket_repository" "test" {
   owner = %[1]q
   name  = %[2]q
   slug  = %[3]q
 }
-`, testUser, rName, rName2)
+`, testUser, rName, rSlug)
 }
 
 func testAccCheckBitbucketRepositoryDestroy(s *terraform.State) error {


### PR DESCRIPTION
Depended on the new API version including https://github.com/DrFaust92/bitbucket-go-client/pull/12

> === RUN   TestAccBitbucketRepository_slug
--- PASS: TestAccBitbucketRepository_slug (6.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-bitbucket/bitbucket   6.399s

fixes #95 