### PR TITLE
chore: add support for local provider debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 *.dll
 *.exe
+*.env
 .DS_Store
 example.tf
-terraform.tfplan
-terraform.tfstate
 bin/
 dist/
 modules-dev/
@@ -14,8 +13,6 @@ website/build
 website/node_modules
 .vagrant/
 *.backup
-./*.tfstate
-.terraform/
 *.log
 *.bak
 *~
@@ -28,6 +25,15 @@ website/node_modules
 website/vendor
 vendor/
 .vscode/
+
+# Terraform
+terraform.tfplan
+terraform.tfstate
+.terraformrc
+./*.tfstate
+.terraform/
+
+terraform-provider-bitbucket
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/main.go
+++ b/main.go
@@ -1,11 +1,21 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/terraform-providers/terraform-provider-bitbucket/bitbucket"
 )
 
 func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: bitbucket.Provider})
+		ProviderFunc: bitbucket.Provider,
+		ProviderAddr: "DrFaust92/bitbucket",
+		Debug:        debug,
+	})
 }


### PR DESCRIPTION
This PR adds support for attaching a [`go-delve`](https://github.com/go-delve/delve) session to the codebase using a `-debug` flag. This follows the documentation of https://developer.hashicorp.com/terraform/plugin/debugging where the implementation of https://developer.hashicorp.com/terraform/plugin/sdkv2/debugging is used.

Together with a local `.terraformrc` and a local backend, I can live test and debug (with VSCode break points) this provider. I thought this might be a nice addition for everyone.
