### PR TITLE
feat(auth): add support for OAuth2 Client Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements
 ------------
 
 - [Terraform](https://www.terraform.io/downloads.html) 1.x
-- [Go](https://golang.org/doc/install) 9 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.19 (to build the provider plugin)
 
 Building The Provider
 ---------------------

--- a/bitbucket/client.go
+++ b/bitbucket/client.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+
+	"golang.org/x/oauth2"
 )
 
 // Error represents a error from the bitbucket api.
@@ -31,15 +33,15 @@ const (
 // Client is the base internal Client to talk to bitbuckets API. This should be a username and password
 // the password should be a app-password.
 type Client struct {
-	Username   *string
-	Password   *string
-	OAuthToken *string
-	HTTPClient *http.Client
+	Username         *string
+	Password         *string
+	OAuthToken       *string
+	OAuthTokenSource oauth2.TokenSource
+	HTTPClient       *http.Client
 }
 
 // Do Will just call the bitbucket api but also add auth to it and some extra headers
 func (c *Client) Do(method, endpoint string, payload *bytes.Buffer, addJsonHeader bool) (*http.Response, error) {
-
 	absoluteendpoint := BitbucketEndpoint + endpoint
 	log.Printf("[DEBUG] Sending request to %s %s", method, absoluteendpoint)
 
@@ -62,8 +64,17 @@ func (c *Client) Do(method, endpoint string, payload *bytes.Buffer, addJsonHeade
 
 	if c.OAuthToken != nil {
 		log.Printf("[DEBUG] Setting Bearer Token")
-		var bearer = "Bearer " + *c.OAuthToken
+		bearer := "Bearer " + *c.OAuthToken
 		req.Header.Add("Authorization", bearer)
+	}
+
+	if c.OAuthTokenSource != nil {
+		token, err := c.OAuthTokenSource.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		token.SetAuthHeader(req)
 	}
 
 	if payload != nil && addJsonHeader {

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,15 +41,48 @@ resource "bitbucket_project" "project" {
 
 The following arguments are supported in the `provider` block:
 
-* `username` - (Optional) Your username used to connect to bitbucket. You can
-  also set this via the environment variable. `BITBUCKET_USERNAME`
+* `username` - (Optional) Username to use for authentication via [Basic
+  Auth](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#basic-auth).
+  You can also set this via the `BITBUCKET_USERNAME` environment variable.
+  If configured, requires `password` to be configured as well.
 
-* `password` - (Optional) Your password used to connect to bitbucket. You can
-  also set this via the environment variable. `BITBUCKET_PASSWORD`
+* `password` - (Optional) Password to use for authentication via [Basic
+  Auth](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#basic-auth).
+  Please note that this has to be an [App
+  Password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/)
+  that has to be created in the [Account
+  Settings](https://bitbucket.org/account/settings/app-passwords/). If
+  configured, requires `username` to be configured as well.
 
-* `oauth_token` - (Optional) Your password used to connect to bitbucket. You can
-also set this via the environment variable. `BITBUCKET_OAUTH_TOKEN`
+* `oauth_client_id` - (Optional) OAuth client ID to use for authentication via
+  [Client Credentials
+  Grant](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#3--client-credentials-grant--4-4-).
+  You can also set this via the `BITBUCKET_OAUTH_CLIENT_ID` environment
+  variable. If configured, requires `oauth_client_secret` to be configured as
+  well.
+
+* `oauth_client_secret` - (Optional) OAuth client secret to use for authentication via
+  [Client Credentials
+  Grant](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#3--client-credentials-grant--4-4-).
+  You can also set this via the `BITBUCKET_OAUTH_CLIENT_SECRET` environment
+  variable. If configured, requires `oauth_client_id` to be configured as well.
+
+* `oauth_token` - (Optional) An OAuth access token used for authentication via
+  [OAuth](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#oauth-2-0).
+  You can also set this via the `BITBUCKET_OAUTH_TOKEN` environment variable.
 
 ## OAuth2 Scopes
 
-To interacte with the Bitbucket API, an [App Password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) is required. App passwords are limited in scope, each API requires certain scopse to interact with, each resource doc will specifiy what are the scopes required to use that resource. See [Docs](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/) for more inforamtion on scopes.
+To interacte with the Bitbucket API, an [App
+Password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) or
+[OAuth Client
+Credentials](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/)
+are required.
+
+App passwords and OAuth client credentials are limited in scope, each API
+requires certain scope to interact with, each resource doc will specify what
+are the scopes required to use that resource.
+
+See the [Bitbucket OAuth
+Documentation](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/)
+for more information on scopes.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/satori/go.uuid v1.2.0
 	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8
+	golang.org/x/oauth2 v0.0.0-20220808172628-8227340efae7
 )
 
 require (
@@ -48,7 +49,6 @@ require (
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/net v0.0.0-20220812174116-3211cb980234 // indirect
-	golang.org/x/oauth2 v0.0.0-20220808172628-8227340efae7 // indirect
 	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect


### PR DESCRIPTION
Authenticating using a bare OAuth2 Access Token is not very convenient since it has limited validity and needs to be aquired by other means outside of the provider.

Bitbucket supports authentication via Client Credentials Grant, which is easier to use.

This change adds support for the `oauth_client_id` and `oauth_client_secret` provider configuration fields (and environment variables) and updates the provider documentation.

This is an alternative to the existing auth via `username`/`password` or `oauth_token`.