### PR TITLE
fix(branch-restriction): handle http errors

### DIFF
--- a/bitbucket/error.go
+++ b/bitbucket/error.go
@@ -1,0 +1,26 @@
+package bitbucket
+
+import (
+	"encoding/json"
+
+	"github.com/DrFaust92/bitbucket-go-client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+func handleClientError(err error) diag.Diagnostics {
+	httpErr, ok := err.(bitbucket.GenericSwaggerError)
+	if ok {
+		var httpError bitbucket.ModelError
+		if err := json.Unmarshal(httpErr.Body(), &httpError); err != nil {
+			return diag.Errorf(string(httpErr.Body()))
+		}
+
+		return diag.Errorf("%s: %s", httpErr.Error(), httpError.Error_.Message)
+	}
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/bitbucket/resource_branch_restriction.go
+++ b/bitbucket/resource_branch_restriction.go
@@ -196,8 +196,8 @@ func resourceBranchRestrictionsCreate(ctx context.Context, d *schema.ResourceDat
 	workspace := d.Get("owner").(string)
 	branchRestrictionReq, _, err := brApi.RepositoriesWorkspaceRepoSlugBranchRestrictionsPost(c.AuthContext, *branchRestriction, repo, workspace)
 
-	if err != nil {
-		return diag.FromErr(err)
+	if diag := handleClientError(err); diag != nil {
+		return diag
 	}
 
 	d.SetId(string(fmt.Sprintf("%v", branchRestrictionReq.Id)))
@@ -218,8 +218,8 @@ func resourceBranchRestrictionsRead(ctx context.Context, d *schema.ResourceData,
 		return nil
 	}
 
-	if err != nil {
-		return diag.FromErr(err)
+	if diag := handleClientError(err); diag != nil {
+		return diag
 	}
 
 	d.SetId(string(fmt.Sprintf("%v", brRes.Id)))
@@ -243,8 +243,8 @@ func resourceBranchRestrictionsUpdate(ctx context.Context, d *schema.ResourceDat
 		*branchRestriction, url.PathEscape(d.Id()),
 		d.Get("repository").(string), d.Get("owner").(string))
 
-	if err != nil {
-		return diag.FromErr(err)
+	if diag := handleClientError(err); diag != nil {
+		return diag
 	}
 
 	return resourceBranchRestrictionsRead(ctx, d, m)
@@ -262,8 +262,8 @@ func resourceBranchRestrictionsDelete(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	if err != nil {
-		return diag.FromErr(err)
+	if diag := handleClientError(err); diag != nil {
+		return diag
 	}
 
 	return nil


### PR DESCRIPTION
This PR makes sure that the HTTP errors (`GenericSwaggerError`) is actually handled whenever it is returned. 

We differentiate between normal `error` objects and `GenericSwaggerError` by testing a type cast. I tried to wrap this logic in a helper function we can easily use throughout any of the resources.

----

Example error output:

**REST Error**
```
bitbucket_branch_restriction.development: Creating...
╷
│ Error: 409 Conflict: a branch restriction with that kind (force) and branch type (development) already exists (id=34493232)
│ 
│   with bitbucket_branch_restriction.development,
│   on example.tf line 13, in resource "bitbucket_branch_restriction" "development":
│   13: resource "bitbucket_branch_restriction" "development" {
│ 
╵
```

**Auth Error**
```
bitbucket_branch_restriction.development: Creating...
╷
│ Error: Login failed due to incorrect login credentials or method.
│ For information on authentication methods for Bitbucket Cloud APIs, visit:
│     https://developer.atlassian.com/cloud/bitbucket/rest/intro/#authentication
│ If you are unsure of which login details or login method to use, visit:
│     https://support.atlassian.com/bitbucket-cloud/docs/log-into-or-connect-to-bitbucket-cloud/
│ 
│ 
│   with bitbucket_branch_restriction.development,
│   on example.tf line 13, in resource "bitbucket_branch_restriction" "development":
│   13: resource "bitbucket_branch_restriction" "development" {
│ 
```

Relates to #93