### PR TITLE
fix: handle http errors of api client

### DIFF
--- a/bitbucket/data_current_user.go
+++ b/bitbucket/data_current_user.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"log"
-	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -70,17 +69,9 @@ func dataReadCurrentUser(ctx context.Context, d *schema.ResourceData, m interfac
 	httpClient := m.(Clients).httpClient
 	usersApi := c.ApiClient.UsersApi
 
-	curUser, curUserRes, err := usersApi.UserGet(c.AuthContext)
-	if err != nil {
-		return diag.Errorf("error reading current user: %s", err)
-	}
-
-	if curUserRes.StatusCode == http.StatusNotFound {
-		return diag.Errorf("user not found")
-	}
-
-	if curUserRes.StatusCode >= http.StatusInternalServerError {
-		return diag.Errorf("internal server error fetching user")
+	curUser, _, err := usersApi.UserGet(c.AuthContext)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Current User: %#v", curUser)

--- a/bitbucket/data_hook_types.go
+++ b/bitbucket/data_hook_types.go
@@ -3,7 +3,6 @@ package bitbucket
 import (
 	"context"
 	"log"
-	"net/http"
 
 	"github.com/DrFaust92/bitbucket-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -52,17 +51,9 @@ func dataReadHookTypes(ctx context.Context, d *schema.ResourceData, m interface{
 	webhooksApi := c.ApiClient.WebhooksApi
 
 	subjectType := d.Get("subject_type").(string)
-	hookTypes, res, err := webhooksApi.HookEventsSubjectTypeGet(c.AuthContext, subjectType)
-	if err != nil {
+	hookTypes, _, err := webhooksApi.HookEventsSubjectTypeGet(c.AuthContext, subjectType)
+	if err := handleClientError(err); err != nil {
 		return diag.FromErr(err)
-	}
-
-	if res.StatusCode == http.StatusNotFound {
-		return diag.Errorf("user not found")
-	}
-
-	if res.StatusCode >= http.StatusInternalServerError {
-		return diag.Errorf("internal server error fetching hook types")
 	}
 
 	d.SetId(subjectType)

--- a/bitbucket/data_user.go
+++ b/bitbucket/data_user.go
@@ -3,7 +3,6 @@ package bitbucket
 import (
 	"context"
 	"log"
-	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -41,17 +40,9 @@ func dataReadUser(ctx context.Context, d *schema.ResourceData, m interface{}) di
 		selectedUser = v.(string)
 	}
 
-	user, userRes, err := usersApi.UsersSelectedUserGet(c.AuthContext, selectedUser)
-	if err != nil {
-		return diag.Errorf("error reading User (%s): %s", selectedUser, err)
-	}
-
-	if userRes.StatusCode == http.StatusNotFound {
-		return diag.Errorf("user not found")
-	}
-
-	if userRes.StatusCode >= http.StatusInternalServerError {
-		return diag.Errorf("internal server error fetching user")
+	user, _, err := usersApi.UsersSelectedUserGet(c.AuthContext, selectedUser)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] User: %#v", user)

--- a/bitbucket/data_workspace.go
+++ b/bitbucket/data_workspace.go
@@ -2,7 +2,6 @@ package bitbucket
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -39,17 +38,9 @@ func dataReadWorkspace(ctx context.Context, d *schema.ResourceData, m interface{
 	workspaceApi := c.ApiClient.WorkspacesApi
 
 	workspace := d.Get("workspace").(string)
-	workspaceReq, res, err := workspaceApi.WorkspacesWorkspaceGet(c.AuthContext, workspace)
-	if err != nil {
+	workspaceReq, _, err := workspaceApi.WorkspacesWorkspaceGet(c.AuthContext, workspace)
+	if err := handleClientError(err); err != nil {
 		return diag.FromErr(err)
-	}
-
-	if res.StatusCode == http.StatusNotFound {
-		return diag.Errorf("workspace not found")
-	}
-
-	if res.StatusCode >= http.StatusInternalServerError {
-		return diag.Errorf("internal server error fetching workspace")
 	}
 
 	d.SetId(workspaceReq.Uuid)

--- a/bitbucket/error.go
+++ b/bitbucket/error.go
@@ -2,24 +2,24 @@ package bitbucket
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/DrFaust92/bitbucket-go-client"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
-func handleClientError(err error) diag.Diagnostics {
+func handleClientError(err error) error {
 	httpErr, ok := err.(bitbucket.GenericSwaggerError)
 	if ok {
 		var httpError bitbucket.ModelError
 		if err := json.Unmarshal(httpErr.Body(), &httpError); err != nil {
-			return diag.Errorf(string(httpErr.Body()))
+			return fmt.Errorf(string(httpErr.Body()))
 		}
 
-		return diag.Errorf("%s: %s", httpErr.Error(), httpError.Error_.Message)
+		return fmt.Errorf("%s: %s", httpErr.Error(), httpError.Error_.Message)
 	}
 
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	return nil

--- a/bitbucket/resource_branch_restriction.go
+++ b/bitbucket/resource_branch_restriction.go
@@ -196,8 +196,8 @@ func resourceBranchRestrictionsCreate(ctx context.Context, d *schema.ResourceDat
 	workspace := d.Get("owner").(string)
 	branchRestrictionReq, _, err := brApi.RepositoriesWorkspaceRepoSlugBranchRestrictionsPost(c.AuthContext, *branchRestriction, repo, workspace)
 
-	if diag := handleClientError(err); diag != nil {
-		return diag
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(fmt.Sprintf("%v", branchRestrictionReq.Id)))
@@ -218,8 +218,8 @@ func resourceBranchRestrictionsRead(ctx context.Context, d *schema.ResourceData,
 		return nil
 	}
 
-	if diag := handleClientError(err); diag != nil {
-		return diag
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(fmt.Sprintf("%v", brRes.Id)))
@@ -243,8 +243,8 @@ func resourceBranchRestrictionsUpdate(ctx context.Context, d *schema.ResourceDat
 		*branchRestriction, url.PathEscape(d.Id()),
 		d.Get("repository").(string), d.Get("owner").(string))
 
-	if diag := handleClientError(err); diag != nil {
-		return diag
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return resourceBranchRestrictionsRead(ctx, d, m)
@@ -262,8 +262,8 @@ func resourceBranchRestrictionsDelete(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	if diag := handleClientError(err); diag != nil {
-		return diag
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/bitbucket/resource_default_reviewers.go
+++ b/bitbucket/resource_default_reviewers.go
@@ -65,14 +65,10 @@ func resourceDefaultReviewersCreate(ctx context.Context, d *schema.ResourceData,
 	workspace := d.Get("owner").(string)
 	for _, user := range d.Get("reviewers").(*schema.Set).List() {
 		userName := user.(string)
-		_, reviewerResp, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(c.AuthContext, repo, userName, workspace)
 
-		if err != nil {
+		_, _, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(c.AuthContext, repo, userName, workspace)
+		if err := handleClientError(err); err != nil {
 			return diag.FromErr(err)
-		}
-
-		if reviewerResp.StatusCode != 200 {
-			return diag.Errorf("failed to create reviewer %s got code %d", userName, reviewerResp.StatusCode)
 		}
 	}
 
@@ -150,30 +146,17 @@ func resourceDefaultReviewersUpdate(ctx context.Context, d *schema.ResourceData,
 
 	for _, user := range add.List() {
 		userName := user.(string)
-		_, reviewerResp, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(c.AuthContext, repo, userName, workspace)
-
-		if err != nil {
+		_, _, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(c.AuthContext, repo, userName, workspace)
+		if err := handleClientError(err); err != nil {
 			return diag.FromErr(err)
-		}
-
-		if reviewerResp.StatusCode != 200 {
-			return diag.Errorf("failed to create reviewer %s got code %d", userName, reviewerResp.StatusCode)
 		}
 	}
 
 	for _, user := range remove.List() {
 		userName := user.(string)
-		reviewerResp, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(c.AuthContext, repo, userName, workspace)
-
-		if err != nil {
+		_, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(c.AuthContext, repo, userName, workspace)
+		if err := handleClientError(err); err != nil {
 			return diag.FromErr(err)
-		}
-
-		if reviewerResp.StatusCode != 204 {
-			return diag.Errorf("[%d] Could not delete %s from default reviewers",
-				reviewerResp.StatusCode,
-				userName,
-			)
 		}
 	}
 
@@ -188,17 +171,9 @@ func resourceDefaultReviewersDelete(ctx context.Context, d *schema.ResourceData,
 	workspace := d.Get("owner").(string)
 	for _, user := range d.Get("reviewers").(*schema.Set).List() {
 		userName := user.(string)
-		reviewerResp, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(c.AuthContext, repo, userName, workspace)
-
-		if err != nil {
+		_, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(c.AuthContext, repo, userName, workspace)
+		if err := handleClientError(err); err != nil {
 			return diag.FromErr(err)
-		}
-
-		if reviewerResp.StatusCode != 204 {
-			return diag.Errorf("[%d] Could not delete %s from default reviewer",
-				reviewerResp.StatusCode,
-				userName,
-			)
 		}
 	}
 	return nil

--- a/bitbucket/resource_deploy_key.go
+++ b/bitbucket/resource_deploy_key.go
@@ -106,14 +106,15 @@ func resourceDeployKeysRead(ctx context.Context, d *schema.ResourceData, m inter
 	}
 
 	deployKey, deployKeyRes, err := deployApi.RepositoriesWorkspaceRepoSlugDeployKeysKeyIdGet(c.AuthContext, keyId, repo, workspace)
-	if err != nil {
-		return diag.Errorf("error reading Deploy Key (%s): %s", d.Id(), err)
-	}
 
 	if deployKeyRes.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Deploy Key (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Deploy Key Response: %#v", deployKey)
@@ -164,8 +165,8 @@ func resourceDeployKeysDelete(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	_, err = deployApi.RepositoriesWorkspaceRepoSlugDeployKeysKeyIdDelete(c.AuthContext, keyId, repo, workspace)
-	if err != nil {
-		return diag.Errorf("error deleting Deploy Key (%s): %s", d.Id(), err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return diag.FromErr(err)

--- a/bitbucket/resource_deployment_variable.go
+++ b/bitbucket/resource_deployment_variable.go
@@ -84,9 +84,8 @@ func resourceDeploymentVariableCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	rvRes, _, err := pipeApi.CreateDeploymentVariable(c.AuthContext, *rvcr, workspace, repoSlug, deployment)
-
-	if err != nil {
-		return diag.Errorf("error creating Deployment Variable (%s): %s", d.Get("deployment").(string), err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.Set("uuid", rvRes.Uuid)
@@ -107,14 +106,15 @@ func resourceDeploymentVariableRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	rvRes, res, err := pipeApi.GetDeploymentVariables(c.AuthContext, workspace, repoSlug, deployment)
-	if err != nil {
-		return diag.Errorf("error reading Deployment Variable (%s): %s", d.Id(), err)
-	}
 
 	if res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Deployment Variable (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	if rvRes.Size < 1 {
@@ -163,9 +163,8 @@ func resourceDeploymentVariableUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	_, _, err = pipeApi.UpdateDeploymentVariable(c.AuthContext, *rvcr, workspace, repoSlug, deployment, d.Get("uuid").(string))
-
-	if err != nil {
-		return diag.Errorf("error updating Deployment Variable (%s): %s", d.Get("deployment").(string), err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return resourceDeploymentVariableRead(ctx, d, m)
@@ -182,8 +181,8 @@ func resourceDeploymentVariableDelete(ctx context.Context, d *schema.ResourceDat
 	}
 
 	_, err = pipeApi.DeleteDeploymentVariable(c.AuthContext, workspace, repoSlug, deployment, d.Get("uuid").(string))
-	if err != nil {
-		return diag.Errorf("error deleting Deployment Variable (%s): %s", d.Id(), err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/bitbucket/resource_forked_repository.go
+++ b/bitbucket/resource_forked_repository.go
@@ -211,9 +211,8 @@ func resourceForkedRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 		Body: optional.NewInterface(requestRepo),
 	}
 	_, _, err := repoApi.RepositoriesWorkspaceRepoSlugForksPost(c.AuthContext, parentRepoSlug, parentWorkspace, repoBody)
-	if err != nil {
-		swaggerErr := err.(bitbucket.GenericSwaggerError)
-		return diag.Errorf("error forking repository (%s) from (%s): %s", repoSlug, parentRepoSlug, string(swaggerErr.Body()))
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(fmt.Sprintf("%s/%s", d.Get("owner").(string), repoSlug)))
@@ -228,8 +227,9 @@ func resourceForkedRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 				fmt.Errorf("Permissions error setting Pipelines config, retrying..."),
 			)
 		}
-		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("unexpected error enabling pipeline for repository (%s): %w", repoSlug, err))
+
+		if err := handleClientError(err); err != nil {
+			return resource.NonRetryableError(err)
 		}
 		return nil
 	})
@@ -265,14 +265,15 @@ func resourceForkedRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 	pipeApi := c.ApiClient.PipelinesApi
 
 	repoRes, res, err := repoApi.RepositoriesWorkspaceRepoSlugGet(c.AuthContext, repoSlug, workspace)
-	if err != nil {
-		return diag.Errorf("error reading repository (%s): %s", d.Id(), err)
-	}
 
 	if res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Repository (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.Set("scm", repoRes.Scm)
@@ -310,8 +311,7 @@ func resourceForkedRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("link", flattenLinks(repoRes.Links))
 
 	pipelinesConfigReq, res, err := pipeApi.GetRepositoryPipelineConfig(c.AuthContext, workspace, repoSlug)
-
-	if err != nil && res.StatusCode != http.StatusNotFound {
+	if err := handleClientError(err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_pipeline_ssh_key.go
+++ b/bitbucket/resource_pipeline_ssh_key.go
@@ -55,9 +55,8 @@ func resourcePipelineSshKeysPut(ctx context.Context, d *schema.ResourceData, m i
 	repo := d.Get("repository").(string)
 	workspace := d.Get("workspace").(string)
 	_, _, err := pipeApi.UpdateRepositoryPipelineKeyPair(c.AuthContext, *pipeSshKey, workspace, repo)
-
-	if err != nil {
-		return diag.Errorf("error creating pipeline ssh key: %s", err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(fmt.Sprintf("%s/%s", workspace, repo)))
@@ -75,9 +74,6 @@ func resourcePipelineSshKeysRead(ctx context.Context, d *schema.ResourceData, m 
 	}
 
 	key, res, err := pipeApi.GetRepositoryPipelineSshKeyPair(c.AuthContext, workspace, repo)
-	if err != nil {
-		return diag.Errorf("error reading Pipeline Ssh Key (%s): %s", d.Id(), err)
-	}
 
 	if res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Pipeline Ssh Key (%s) not found, removing from state", d.Id())
@@ -85,8 +81,8 @@ func resourcePipelineSshKeysRead(ctx context.Context, d *schema.ResourceData, m 
 		return nil
 	}
 
-	if res.Body == nil {
-		return diag.Errorf("error getting Pipeline Ssh Key (%s): empty response", d.Id())
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.Set("repository", repo)
@@ -107,9 +103,8 @@ func resourcePipelineSshKeysDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	_, err = pipeApi.DeleteRepositoryPipelineKeyPair(c.AuthContext, workspace, repo)
-
-	if err != nil {
-		return diag.Errorf("error deleting Pipeline Ssh Key (%s): %s", d.Id(), err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return diag.FromErr(err)

--- a/bitbucket/resource_pipeline_ssh_known_host.go
+++ b/bitbucket/resource_pipeline_ssh_known_host.go
@@ -82,9 +82,8 @@ func resourcePipelineSshKnownHostsCreate(ctx context.Context, d *schema.Resource
 	repo := d.Get("repository").(string)
 	workspace := d.Get("workspace").(string)
 	host, _, err := pipeApi.CreateRepositoryPipelineKnownHost(c.AuthContext, *pipeSshKnownHost, workspace, repo)
-
-	if err != nil {
-		return diag.Errorf("error creating pipeline ssh known host: %s", err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(string(fmt.Sprintf("%s/%s/%s", workspace, repo, host.Uuid)))
@@ -104,9 +103,8 @@ func resourcePipelineSshKnownHostsUpdate(ctx context.Context, d *schema.Resource
 	pipeSshKnownHost := expandPipelineSshKnownHost(d)
 	log.Printf("[DEBUG] Pipeline Ssh Key Request: %#v", pipeSshKnownHost)
 	_, _, err = pipeApi.UpdateRepositoryPipelineKnownHost(c.AuthContext, *pipeSshKnownHost, workspace, repo, uuid)
-
-	if err != nil {
-		return diag.Errorf("error updating pipeline ssh known host: %s", err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return resourcePipelineSshKnownHostsRead(ctx, d, m)
@@ -122,9 +120,6 @@ func resourcePipelineSshKnownHostsRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	host, res, err := pipeApi.GetRepositoryPipelineKnownHost(c.AuthContext, workspace, repo, uuid)
-	if err != nil {
-		return diag.Errorf("error reading Pipeline Ssh known host (%s): %s", d.Id(), err)
-	}
 
 	if res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Pipeline Ssh known host (%s) not found, removing from state", d.Id())
@@ -132,8 +127,8 @@ func resourcePipelineSshKnownHostsRead(ctx context.Context, d *schema.ResourceDa
 		return nil
 	}
 
-	if res.Body == nil {
-		return diag.Errorf("error getting Pipeline Ssh known host (%s): empty response", d.Id())
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.Set("repository", repo)
@@ -154,9 +149,8 @@ func resourcePipelineSshKnownHostsDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	_, err = pipeApi.DeleteRepositoryPipelineKnownHost(c.AuthContext, workspace, repo, uuid)
-
-	if err != nil {
-		return diag.Errorf("error deleting Pipeline Ssh known host (%s): %s", d.Id(), err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return diag.FromErr(err)

--- a/bitbucket/resource_project_default_reviewers.go
+++ b/bitbucket/resource_project_default_reviewers.go
@@ -52,14 +52,9 @@ func resourceProjectDefaultReviewersCreate(ctx context.Context, d *schema.Resour
 
 	for _, user := range d.Get("reviewers").(*schema.Set).List() {
 		userName := user.(string)
-		_, reviewerResp, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserPut(c.AuthContext, project, userName, workspace)
-
-		if err != nil {
+		_, _, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserPut(c.AuthContext, project, userName, workspace)
+		if err := handleClientError(err); err != nil {
 			return diag.FromErr(err)
-		}
-
-		if reviewerResp.StatusCode != 200 {
-			return diag.Errorf("failed to create reviewer %s got code %d", userName, reviewerResp.StatusCode)
 		}
 	}
 
@@ -138,30 +133,17 @@ func resourceProjectDefaultReviewersUpdate(ctx context.Context, d *schema.Resour
 
 	for _, user := range add.List() {
 		userName := user.(string)
-		_, reviewerResp, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserPut(c.AuthContext, project, userName, workspace)
-
-		if err != nil {
+		_, _, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserPut(c.AuthContext, project, userName, workspace)
+		if err := handleClientError(err); err != nil {
 			return diag.FromErr(err)
-		}
-
-		if reviewerResp.StatusCode != 200 {
-			return diag.Errorf("failed to create reviewer %s got code %d", userName, reviewerResp.StatusCode)
 		}
 	}
 
 	for _, user := range remove.List() {
 		userName := user.(string)
-		reviewerResp, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserDelete(c.AuthContext, project, userName, workspace)
-
-		if err != nil {
+		_, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserDelete(c.AuthContext, project, userName, workspace)
+		if err := handleClientError(err); err != nil {
 			return diag.FromErr(err)
-		}
-
-		if reviewerResp.StatusCode != 204 {
-			return diag.Errorf("[%d] Could not delete %s from default reviewers",
-				reviewerResp.StatusCode,
-				userName,
-			)
 		}
 	}
 
@@ -176,17 +158,9 @@ func resourceProjectDefaultReviewersDelete(ctx context.Context, d *schema.Resour
 	workspace := d.Get("workspace").(string)
 	for _, user := range d.Get("reviewers").(*schema.Set).List() {
 		userName := user.(string)
-		reviewerResp, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserDelete(c.AuthContext, project, userName, workspace)
-
-		if err != nil {
+		_, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserDelete(c.AuthContext, project, userName, workspace)
+		if err := handleClientError(err); err != nil {
 			return diag.FromErr(err)
-		}
-
-		if reviewerResp.StatusCode != 204 {
-			return diag.Errorf("[%d] Could not delete %s from default reviewer",
-				reviewerResp.StatusCode,
-				userName,
-			)
 		}
 	}
 	return nil

--- a/bitbucket/resource_repository_variable.go
+++ b/bitbucket/resource_repository_variable.go
@@ -67,9 +67,8 @@ func resourceRepositoryVariableCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	rvRes, _, err := pipeApi.CreateRepositoryPipelineVariable(c.AuthContext, rvcr, workspace, repoSlug)
-
-	if err != nil {
-		return diag.Errorf("error creating Repository Variable (%s): %s", repo, err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.Set("uuid", rvRes.Uuid)
@@ -89,13 +88,15 @@ func resourceRepositoryVariableRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	rvRes, res, err := pipeApi.GetRepositoryPipelineVariable(c.AuthContext, workspace, repoSlug, d.Get("uuid").(string))
-	if err != nil {
-		return diag.Errorf("error reading Repository Variable (%s): %s", d.Id(), err)
-	}
+
 	if res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Repository Variable (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
+	}
+
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.Set("uuid", rvRes.Uuid)
@@ -124,8 +125,8 @@ func resourceRepositoryVariableUpdate(ctx context.Context, d *schema.ResourceDat
 	rvcr := newRepositoryVariableFromResource(d)
 
 	_, _, err = pipeApi.UpdateRepositoryPipelineVariable(c.AuthContext, rvcr, workspace, repoSlug, d.Get("uuid").(string))
-	if err != nil {
-		return diag.Errorf("error updating Repository Variable (%s): %s", d.Id(), err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return resourceRepositoryVariableRead(ctx, d, m)
@@ -142,8 +143,8 @@ func resourceRepositoryVariableDelete(ctx context.Context, d *schema.ResourceDat
 	}
 
 	_, err = pipeApi.DeleteRepositoryPipelineVariable(c.AuthContext, workspace, repoSlug, d.Get("uuid").(string))
-	if err != nil {
-		return diag.Errorf("error deleting Repository Variable (%s): %s", d.Id(), err)
+	if err := handleClientError(err); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil


### PR DESCRIPTION
This is a continuation of the work done in https://github.com/DrFaust92/terraform-provider-bitbucket/pull/125

---

Handle all HTTP Error responses (`GenericSwaggerError`) wherever the API Client is used. So the scope of this ticket is only the usage of API Client. The following changes are applied in this PR:

- Return a `error` object instead of the `Diagnostics` object to better control the error aggregation (for example, needed in `resource_forked_repository.go`). 
- Remove redundant error messages and simply propagate the error message.
- Make sure the resource reset based on `res.StatusCode == http.StatusNotFound` happens after the HTTP Error handling. This is because HTTP 404 is also thrown as a `GenericSwaggerError` in the API client.

Fixes #93

---

All, except one, acceptance test succeeds. This one failing test also fails on the current master branch, and as such is unrelated to this PR. I created a separate issue for this (see #127).