### PR TITLE
fix(data_workspace): only test on attribute existence

### DIFF
--- a/bitbucket/data_workspace_test.go
+++ b/bitbucket/data_workspace_test.go
@@ -21,7 +21,7 @@ func TestAccDataSourceWorkspace_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "workspace", workspace),
 					resource.TestCheckResourceAttrSet(dataSourceName, "name"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "slug"),
-					resource.TestCheckResourceAttr(dataSourceName, "is_private", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "is_private"),
 				),
 			},
 		},


### PR DESCRIPTION
This PR makes the data_workspace_test is a bit more stable. Previously, the test was based on a very specific Workspace set up, where `is_private` has to be set to `true`.

To make this test less dependent on a specific set up of a manual created workspace. I now only test if this attribute is set.

fixes #127 