### PR TITLE
docs(workspace-hook): document all attributes

### DIFF
--- a/docs/resources/workspace_hook.md
+++ b/docs/resources/workspace_hook.md
@@ -17,7 +17,7 @@ OAuth2 Scopes: `webhook`
 ## Example Usage
 
 ```hcl
-resource "bitbucket_hook" "deploy_on_push" {
+resource "bitbucket_workspace_hook" "deploy_on_push" {
   workspace   = "myteam"
   url         = "https://mywebhookservice.mycompany.com/deploy-on-push"
   description = "Deploy the code via my webhook"
@@ -37,6 +37,14 @@ The following arguments are supported:
 * `url` - (Required) Where to POST to.
 * `description` - (Required) The name / description to show in the UI.
 * `events` - (Required) The events this webhook is subscribed to. Valid values can be found at [Bitbucket Webhook Docs](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-hooks-post).
+* `active` - (Optional) Whether the webhook configuration is active or not (Default: `true`).
+* `skip_cert_verification` - (Optional) Whether to skip certificate verification or not (Default: `true`).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `uuid` - The UUID of the workspace webhook.
 
 ## Import
 


### PR DESCRIPTION
I stumbled across the incorrect example which seemed to be copied from the `bitbucket_hook` resource documentation and added documentation for missing arguments and exported attributes while I was at it.