### PR TITLE
ignore error when pipeline config not found

### DIFF
--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -357,7 +357,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, m inter
 	d.Set("link", flattenLinks(repoRes.Links))
 
 	pipelinesConfigReq, res, err := pipeApi.GetRepositoryPipelineConfig(c.AuthContext, workspace, repoSlug)
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(err); err != nil && res.StatusCode != http.StatusNotFound {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
After updating from version 2.22.0 to 2.29.0 i get always a 404 error, on existing repos: 

```
│ Error: 404 Not Found: Not found
│
│   with module.repos["example"].bitbucket_repository.this,
│   on modules/bitbucket-repo/main.tf line 1, in resource "bitbucket_repository" "this":
│    1: resource "bitbucket_repository" "this" {
```

This is related to this commit: https://github.com/DrFaust92/terraform-provider-bitbucket/commit/c443cd1e07c19bc5c56ecafcfc105a319def1e2a#diff-3bd5177b56ea90e3601af4cf3155bea57949347bead0d21d6526c518f499f916L314

We are not using the bitbucket piplines.

maybe related to: #141