### PR TITLE
replacing the hooks event link with more appropiate one

### DIFF
--- a/docs/resources/hook.md
+++ b/docs/resources/hook.md
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `repository` - (Required) The name of the repository.
 * `url` - (Required) Where to POST to.
 * `description` - (Required) The name / description to show in the UI.
-* `events` - (Required) The events this webhook is subscribed to. Valid values can be found at [Bitbucket Webhook Docs](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-hooks-post).
+* `events` - (Required) The events this webhook is subscribed to. Valid values can be found at [Bitbucket Event Payloads Docs](https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/).
 
 ## Import
 


### PR DESCRIPTION
https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/ has more details about what events to use and their names