### PR TITLE
ignore 404 error when forked repo pipeline config not found

### DIFF
--- a/bitbucket/resource_forked_repository.go
+++ b/bitbucket/resource_forked_repository.go
@@ -311,7 +311,7 @@ func resourceForkedRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("link", flattenLinks(repoRes.Links))
 
 	pipelinesConfigReq, res, err := pipeApi.GetRepositoryPipelineConfig(c.AuthContext, workspace, repoSlug)
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(err); err != nil && res.StatusCode != http.StatusNotFound {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
This is a fix for the bug reported in issue https://github.com/DrFaust92/terraform-provider-bitbucket/issues/178.