### PR TITLE
document repo group permissions oauth limitation

### DIFF
--- a/docs/resources/repository_group_permission.md
+++ b/docs/resources/repository_group_permission.md
@@ -14,6 +14,8 @@ This allows you set explicit group permission for a repository.
 
 OAuth2 Scopes: `repository:admin`
 
+Note: can only be used when authenticating with Bitbucket CLoud using an _app password_. Authenticating via an OAuth flow gives a 403 error due to a [restriction in the Bitbucket Cloud API](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-permissions-config-groups-group-slug-put).
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Using the `bitbucket_repository_group_permission` resource when authenticating with Bitbucket using OAuth gives a 403 error. It only works when authenticating via an app password.

This PR documents this limitation.