### PR TITLE
fix: make sure the authorization error is correctly shown to the end user

### DIFF
--- a/bitbucket/data_current_user.go
+++ b/bitbucket/data_current_user.go
@@ -69,8 +69,8 @@ func dataReadCurrentUser(ctx context.Context, d *schema.ResourceData, m interfac
 	httpClient := m.(Clients).httpClient
 	usersApi := c.ApiClient.UsersApi
 
-	curUser, _, err := usersApi.UserGet(c.AuthContext)
-	if err := handleClientError(err); err != nil {
+	curUser, res, err := usersApi.UserGet(c.AuthContext)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/data_deployments.go
+++ b/bitbucket/data_deployments.go
@@ -43,8 +43,8 @@ func dataReadDeployments(ctx context.Context, d *schema.ResourceData, m interfac
 	workspace := d.Get("workspace").(string)
 	repoId := d.Get("repository").(string)
 
-	deploymentsResp, _, err := deployApi.GetEnvironmentsForRepository(c.AuthContext, workspace, repoId, nil)
-	if err := handleClientError(err); err != nil {
+	deploymentsResp, res, err := deployApi.GetEnvironmentsForRepository(c.AuthContext, workspace, repoId, nil)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/data_hook_types.go
+++ b/bitbucket/data_hook_types.go
@@ -51,8 +51,8 @@ func dataReadHookTypes(ctx context.Context, d *schema.ResourceData, m interface{
 	webhooksApi := c.ApiClient.WebhooksApi
 
 	subjectType := d.Get("subject_type").(string)
-	hookTypes, _, err := webhooksApi.HookEventsSubjectTypeGet(c.AuthContext, subjectType, nil)
-	if err := handleClientError(err); err != nil {
+	hookTypes, res, err := webhooksApi.HookEventsSubjectTypeGet(c.AuthContext, subjectType, nil)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/data_user.go
+++ b/bitbucket/data_user.go
@@ -40,8 +40,8 @@ func dataReadUser(ctx context.Context, d *schema.ResourceData, m interface{}) di
 		selectedUser = v.(string)
 	}
 
-	user, _, err := usersApi.UsersSelectedUserGet(c.AuthContext, selectedUser)
-	if err := handleClientError(err); err != nil {
+	user, res, err := usersApi.UsersSelectedUserGet(c.AuthContext, selectedUser)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/data_workspace.go
+++ b/bitbucket/data_workspace.go
@@ -38,8 +38,8 @@ func dataReadWorkspace(ctx context.Context, d *schema.ResourceData, m interface{
 	workspaceApi := c.ApiClient.WorkspacesApi
 
 	workspace := d.Get("workspace").(string)
-	workspaceReq, _, err := workspaceApi.WorkspacesWorkspaceGet(c.AuthContext, workspace)
-	if err := handleClientError(err); err != nil {
+	workspaceReq, res, err := workspaceApi.WorkspacesWorkspaceGet(c.AuthContext, workspace)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/data_workspace_members.go
+++ b/bitbucket/data_workspace_members.go
@@ -61,8 +61,8 @@ func dataReadWorkspaceMembers(ctx context.Context, d *schema.ResourceData, m int
 	options := bitbucket.WorkspacesApiWorkspacesWorkspaceMembersGetOpts{}
 
 	for {
-		flattenAccountsReq, _, err := workspaceApi.WorkspacesWorkspaceMembersGet(c.AuthContext, workspace, &options)
-		if err := handleClientError(err); err != nil {
+		flattenAccountsReq, res, err := workspaceApi.WorkspacesWorkspaceMembersGet(c.AuthContext, workspace, &options)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 

--- a/bitbucket/resource_branch_restriction.go
+++ b/bitbucket/resource_branch_restriction.go
@@ -194,9 +194,8 @@ func resourceBranchRestrictionsCreate(ctx context.Context, d *schema.ResourceDat
 
 	repo := d.Get("repository").(string)
 	workspace := d.Get("owner").(string)
-	branchRestrictionReq, _, err := brApi.RepositoriesWorkspaceRepoSlugBranchRestrictionsPost(c.AuthContext, *branchRestriction, repo, workspace)
-
-	if err := handleClientError(err); err != nil {
+	branchRestrictionReq, res, err := brApi.RepositoriesWorkspaceRepoSlugBranchRestrictionsPost(c.AuthContext, *branchRestriction, repo, workspace)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -218,7 +217,7 @@ func resourceBranchRestrictionsRead(ctx context.Context, d *schema.ResourceData,
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -239,11 +238,11 @@ func resourceBranchRestrictionsUpdate(ctx context.Context, d *schema.ResourceDat
 	brApi := c.ApiClient.BranchRestrictionsApi
 	branchRestriction := createBranchRestriction(d)
 
-	_, _, err := brApi.RepositoriesWorkspaceRepoSlugBranchRestrictionsIdPut(c.AuthContext,
+	_, res, err := brApi.RepositoriesWorkspaceRepoSlugBranchRestrictionsIdPut(c.AuthContext,
 		*branchRestriction, url.PathEscape(d.Id()),
 		d.Get("repository").(string), d.Get("owner").(string))
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -262,7 +261,7 @@ func resourceBranchRestrictionsDelete(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_commit_file.go
+++ b/bitbucket/resource_commit_file.go
@@ -115,22 +115,22 @@ func resourceCommitFilePut(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(err)
 	}
 
-	response, err := client.PostWithContentType(fmt.Sprintf("2.0/repositories/%s/%s/src",
+	res, err := client.PostWithContentType(fmt.Sprintf("2.0/repositories/%s/%s/src",
 		workspace,
 		repoSlug,
 	), writer.FormDataContentType(), body)
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
-	if response.StatusCode != http.StatusCreated {
+	if res.StatusCode != http.StatusCreated {
 		return diag.FromErr(fmt.Errorf(""))
 	}
 
 	d.SetId(string(fmt.Sprintf("%s/%s/%s/%s", workspace, repoSlug, branch, filename)))
 
-	location, _ := response.Location()
+	location, _ := res.Location()
 	splitPath := strings.Split(location.Path, "/")
 	d.Set("commit_sha", splitPath[len(splitPath)-1])
 
@@ -146,9 +146,9 @@ func resourceCommitFileRead(ctx context.Context, d *schema.ResourceData, m inter
 	filename := d.Get("filename").(string)
 	commit := d.Get("commit_sha").(string)
 
-	_, _, err := sourceApi.RepositoriesWorkspaceRepoSlugSrcCommitPathGet(c.AuthContext, commit, filename, repoSlug, workspace, &bitbucket.SourceApiRepositoriesWorkspaceRepoSlugSrcCommitPathGetOpts{})
+	_, res, err := sourceApi.RepositoriesWorkspaceRepoSlugSrcCommitPathGet(c.AuthContext, commit, filename, repoSlug, workspace, &bitbucket.SourceApiRepositoriesWorkspaceRepoSlugSrcCommitPathGetOpts{})
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_default_reviewers.go
+++ b/bitbucket/resource_default_reviewers.go
@@ -52,8 +52,8 @@ func resourceDefaultReviewersCreate(ctx context.Context, d *schema.ResourceData,
 	for _, user := range d.Get("reviewers").(*schema.Set).List() {
 		userName := user.(string)
 
-		_, _, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(c.AuthContext, repo, userName, workspace)
-		if err := handleClientError(err); err != nil {
+		_, res, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(c.AuthContext, repo, userName, workspace)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -77,7 +77,7 @@ func resourceDefaultReviewersRead(ctx context.Context, d *schema.ResourceData, m
 
 	for {
 		reviewers, res, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersGet(c.AuthContext, repo, owner, &options)
-		if err := handleClientError(err); err != nil {
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 
@@ -121,16 +121,16 @@ func resourceDefaultReviewersUpdate(ctx context.Context, d *schema.ResourceData,
 
 	for _, user := range add.List() {
 		userName := user.(string)
-		_, _, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(c.AuthContext, repo, userName, workspace)
-		if err := handleClientError(err); err != nil {
+		_, res, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernamePut(c.AuthContext, repo, userName, workspace)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	for _, user := range remove.List() {
 		userName := user.(string)
-		_, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(c.AuthContext, repo, userName, workspace)
-		if err := handleClientError(err); err != nil {
+		res, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(c.AuthContext, repo, userName, workspace)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -146,8 +146,8 @@ func resourceDefaultReviewersDelete(ctx context.Context, d *schema.ResourceData,
 	workspace := d.Get("owner").(string)
 	for _, user := range d.Get("reviewers").(*schema.Set).List() {
 		userName := user.(string)
-		_, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(c.AuthContext, repo, userName, workspace)
-		if err := handleClientError(err); err != nil {
+		res, err := prApi.RepositoriesWorkspaceRepoSlugDefaultReviewersTargetUsernameDelete(c.AuthContext, repo, userName, workspace)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/bitbucket/resource_deploy_key.go
+++ b/bitbucket/resource_deploy_key.go
@@ -105,15 +105,15 @@ func resourceDeployKeysRead(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
-	deployKey, deployKeyRes, err := deployApi.RepositoriesWorkspaceRepoSlugDeployKeysKeyIdGet(c.AuthContext, keyId, repo, workspace)
+	deployKey, res, err := deployApi.RepositoriesWorkspaceRepoSlugDeployKeysKeyIdGet(c.AuthContext, keyId, repo, workspace)
 
-	if deployKeyRes.StatusCode == http.StatusNotFound {
+	if res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Deploy Key (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -164,8 +164,8 @@ func resourceDeployKeysDelete(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	_, err = deployApi.RepositoriesWorkspaceRepoSlugDeployKeysKeyIdDelete(c.AuthContext, keyId, repo, workspace)
-	if err := handleClientError(err); err != nil {
+	res, err := deployApi.RepositoriesWorkspaceRepoSlugDeployKeysKeyIdDelete(c.AuthContext, keyId, repo, workspace)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_deployment.go
+++ b/bitbucket/resource_deployment.go
@@ -248,8 +248,8 @@ func resourceDeploymentDelete(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	_, err = deployApi.DeleteEnvironmentForRepository(c.AuthContext, workspaceId, repoId, d.Get("uuid").(string))
-	if err := handleClientError(err); err != nil {
+	res, err := deployApi.DeleteEnvironmentForRepository(c.AuthContext, workspaceId, repoId, d.Get("uuid").(string))
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_deployment_variable.go
+++ b/bitbucket/resource_deployment_variable.go
@@ -83,8 +83,8 @@ func resourceDeploymentVariableCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	rvRes, _, err := pipeApi.CreateDeploymentVariable(c.AuthContext, *rvcr, workspace, repoSlug, deployment)
-	if err := handleClientError(err); err != nil {
+	rvRes, res, err := pipeApi.CreateDeploymentVariable(c.AuthContext, *rvcr, workspace, repoSlug, deployment)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -113,7 +113,7 @@ func resourceDeploymentVariableRead(ctx context.Context, d *schema.ResourceData,
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -162,8 +162,8 @@ func resourceDeploymentVariableUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	_, _, err = pipeApi.UpdateDeploymentVariable(c.AuthContext, *rvcr, workspace, repoSlug, deployment, d.Get("uuid").(string))
-	if err := handleClientError(err); err != nil {
+	_, res, err := pipeApi.UpdateDeploymentVariable(c.AuthContext, *rvcr, workspace, repoSlug, deployment, d.Get("uuid").(string))
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -180,8 +180,8 @@ func resourceDeploymentVariableDelete(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	_, err = pipeApi.DeleteDeploymentVariable(c.AuthContext, workspace, repoSlug, deployment, d.Get("uuid").(string))
-	if err := handleClientError(err); err != nil {
+	res, err := pipeApi.DeleteDeploymentVariable(c.AuthContext, workspace, repoSlug, deployment, d.Get("uuid").(string))
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_forked_repository.go
+++ b/bitbucket/resource_forked_repository.go
@@ -210,8 +210,8 @@ func resourceForkedRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 	repoBody := &bitbucket.RepositoriesApiRepositoriesWorkspaceRepoSlugForksPostOpts{
 		Body: optional.NewInterface(requestRepo),
 	}
-	_, _, err := repoApi.RepositoriesWorkspaceRepoSlugForksPost(c.AuthContext, parentRepoSlug, parentWorkspace, repoBody)
-	if err := handleClientError(err); err != nil {
+	_, res, err := repoApi.RepositoriesWorkspaceRepoSlugForksPost(c.AuthContext, parentRepoSlug, parentWorkspace, repoBody)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -228,7 +228,7 @@ func resourceForkedRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 			)
 		}
 
-		if err := handleClientError(err); err != nil {
+		if err := handleClientError(pipelineResponse, err); err != nil {
 			return resource.NonRetryableError(err)
 		}
 		return nil
@@ -272,7 +272,7 @@ func resourceForkedRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -311,7 +311,7 @@ func resourceForkedRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("link", flattenLinks(repoRes.Links))
 
 	pipelinesConfigReq, res, err := pipeApi.GetRepositoryPipelineConfig(c.AuthContext, workspace, repoSlug)
-	if err := handleClientError(err); err != nil && res.StatusCode != http.StatusNotFound {
+	if err := handleClientError(res, err); err != nil && res.StatusCode != http.StatusNotFound {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_pipeline_schedule.go
+++ b/bitbucket/resource_pipeline_schedule.go
@@ -102,8 +102,8 @@ func resourcePipelineScheduleCreate(ctx context.Context, d *schema.ResourceData,
 
 	repo := d.Get("repository").(string)
 	workspace := d.Get("workspace").(string)
-	schedule, _, err := pipeApi.CreateRepositoryPipelineSchedule(c.AuthContext, *pipeSchedule, workspace, repo)
-	if err := handleClientError(err); err != nil {
+	schedule, res, err := pipeApi.CreateRepositoryPipelineSchedule(c.AuthContext, *pipeSchedule, workspace, repo)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -111,8 +111,8 @@ func resourcePipelineScheduleCreate(ctx context.Context, d *schema.ResourceData,
 
 	if !d.Get("enabled").(bool) {
 		pipeScheduleUpdate := expandUpdatePipelineSchedule(d)
-		_, _, err = pipeApi.UpdateRepositoryPipelineSchedule(c.AuthContext, *pipeScheduleUpdate, workspace, repo, schedule.Uuid)
-		if err := handleClientError(err); err != nil {
+		_, res, err = pipeApi.UpdateRepositoryPipelineSchedule(c.AuthContext, *pipeScheduleUpdate, workspace, repo, schedule.Uuid)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -131,8 +131,8 @@ func resourcePipelineScheduleUpdate(ctx context.Context, d *schema.ResourceData,
 
 	pipeScheduleUpdate := expandUpdatePipelineSchedule(d)
 	log.Printf("[DEBUG] Pipeline Schedule Request: %#v", pipeScheduleUpdate)
-	_, _, err = pipeApi.UpdateRepositoryPipelineSchedule(c.AuthContext, *pipeScheduleUpdate, workspace, repo, uuid)
-	if err := handleClientError(err); err != nil {
+	_, res, err := pipeApi.UpdateRepositoryPipelineSchedule(c.AuthContext, *pipeScheduleUpdate, workspace, repo, uuid)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -156,7 +156,7 @@ func resourcePipelineScheduleRead(ctx context.Context, d *schema.ResourceData, m
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -179,8 +179,8 @@ func resourcePipelineScheduleDelete(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	_, err = pipeApi.DeleteRepositoryPipelineSchedule(c.AuthContext, workspace, repo, uuid)
-	if err := handleClientError(err); err != nil {
+	res, err := pipeApi.DeleteRepositoryPipelineSchedule(c.AuthContext, workspace, repo, uuid)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_pipeline_ssh_key.go
+++ b/bitbucket/resource_pipeline_ssh_key.go
@@ -54,8 +54,8 @@ func resourcePipelineSshKeysPut(ctx context.Context, d *schema.ResourceData, m i
 
 	repo := d.Get("repository").(string)
 	workspace := d.Get("workspace").(string)
-	_, _, err := pipeApi.UpdateRepositoryPipelineKeyPair(c.AuthContext, *pipeSshKey, workspace, repo)
-	if err := handleClientError(err); err != nil {
+	_, res, err := pipeApi.UpdateRepositoryPipelineKeyPair(c.AuthContext, *pipeSshKey, workspace, repo)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -81,7 +81,7 @@ func resourcePipelineSshKeysRead(ctx context.Context, d *schema.ResourceData, m 
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -102,8 +102,8 @@ func resourcePipelineSshKeysDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	_, err = pipeApi.DeleteRepositoryPipelineKeyPair(c.AuthContext, workspace, repo)
-	if err := handleClientError(err); err != nil {
+	res, err := pipeApi.DeleteRepositoryPipelineKeyPair(c.AuthContext, workspace, repo)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_pipeline_ssh_known_host.go
+++ b/bitbucket/resource_pipeline_ssh_known_host.go
@@ -81,8 +81,8 @@ func resourcePipelineSshKnownHostsCreate(ctx context.Context, d *schema.Resource
 
 	repo := d.Get("repository").(string)
 	workspace := d.Get("workspace").(string)
-	host, _, err := pipeApi.CreateRepositoryPipelineKnownHost(c.AuthContext, *pipeSshKnownHost, workspace, repo)
-	if err := handleClientError(err); err != nil {
+	host, res, err := pipeApi.CreateRepositoryPipelineKnownHost(c.AuthContext, *pipeSshKnownHost, workspace, repo)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -102,8 +102,8 @@ func resourcePipelineSshKnownHostsUpdate(ctx context.Context, d *schema.Resource
 
 	pipeSshKnownHost := expandPipelineSshKnownHost(d)
 	log.Printf("[DEBUG] Pipeline Ssh Key Request: %#v", pipeSshKnownHost)
-	_, _, err = pipeApi.UpdateRepositoryPipelineKnownHost(c.AuthContext, *pipeSshKnownHost, workspace, repo, uuid)
-	if err := handleClientError(err); err != nil {
+	_, res, err := pipeApi.UpdateRepositoryPipelineKnownHost(c.AuthContext, *pipeSshKnownHost, workspace, repo, uuid)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -127,7 +127,7 @@ func resourcePipelineSshKnownHostsRead(ctx context.Context, d *schema.ResourceDa
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -148,8 +148,8 @@ func resourcePipelineSshKnownHostsDelete(ctx context.Context, d *schema.Resource
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	_, err = pipeApi.DeleteRepositoryPipelineKnownHost(c.AuthContext, workspace, repo, uuid)
-	if err := handleClientError(err); err != nil {
+	res, err := pipeApi.DeleteRepositoryPipelineKnownHost(c.AuthContext, workspace, repo, uuid)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_project.go
+++ b/bitbucket/resource_project.go
@@ -120,8 +120,8 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	log.Printf("[DEBUG] Project Update Body: %#v", project)
 	project.Links = nil
 
-	prj, _, err := projectApi.WorkspacesWorkspaceProjectsProjectKeyPut(c.AuthContext, *project, projectKey, d.Get("owner").(string))
-	if err := handleClientError(err); err != nil {
+	prj, res, err := projectApi.WorkspacesWorkspaceProjectsProjectKeyPut(c.AuthContext, *project, projectKey, d.Get("owner").(string))
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -170,8 +170,8 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	log.Printf("[DEBUG] Project Create Body: %#v", project)
 
-	projRes, _, err := projectApi.WorkspacesWorkspaceProjectsPost(c.AuthContext, *project, owner)
-	if err := handleClientError(err); err != nil {
+	projRes, res, err := projectApi.WorkspacesWorkspaceProjectsPost(c.AuthContext, *project, owner)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -209,7 +209,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -235,8 +235,8 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, m interf
 	c := m.(Clients).genClient
 	projectApi := c.ApiClient.ProjectsApi
 
-	_, err := projectApi.WorkspacesWorkspaceProjectsProjectKeyDelete(c.AuthContext, projectKey, d.Get("owner").(string))
-	if err := handleClientError(err); err != nil {
+	res, err := projectApi.WorkspacesWorkspaceProjectsProjectKeyDelete(c.AuthContext, projectKey, d.Get("owner").(string))
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_project_default_reviewers.go
+++ b/bitbucket/resource_project_default_reviewers.go
@@ -52,8 +52,8 @@ func resourceProjectDefaultReviewersCreate(ctx context.Context, d *schema.Resour
 
 	for _, user := range d.Get("reviewers").(*schema.Set).List() {
 		userName := user.(string)
-		_, _, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserPut(c.AuthContext, project, userName, workspace)
-		if err := handleClientError(err); err != nil {
+		_, res, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserPut(c.AuthContext, project, userName, workspace)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -76,7 +76,7 @@ func resourceProjectDefaultReviewersRead(ctx context.Context, d *schema.Resource
 
 	for {
 		reviewers, res, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersGet(c.AuthContext, project, workspace, &options)
-		if err := handleClientError(err); err != nil {
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 
@@ -120,16 +120,16 @@ func resourceProjectDefaultReviewersUpdate(ctx context.Context, d *schema.Resour
 
 	for _, user := range add.List() {
 		userName := user.(string)
-		_, _, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserPut(c.AuthContext, project, userName, workspace)
-		if err := handleClientError(err); err != nil {
+		_, res, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserPut(c.AuthContext, project, userName, workspace)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	for _, user := range remove.List() {
 		userName := user.(string)
-		_, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserDelete(c.AuthContext, project, userName, workspace)
-		if err := handleClientError(err); err != nil {
+		res, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserDelete(c.AuthContext, project, userName, workspace)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -145,8 +145,8 @@ func resourceProjectDefaultReviewersDelete(ctx context.Context, d *schema.Resour
 	workspace := d.Get("workspace").(string)
 	for _, user := range d.Get("reviewers").(*schema.Set).List() {
 		userName := user.(string)
-		_, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserDelete(c.AuthContext, project, userName, workspace)
-		if err := handleClientError(err); err != nil {
+		res, err := projectsApi.WorkspacesWorkspaceProjectsProjectKeyDefaultReviewersSelectedUserDelete(c.AuthContext, project, userName, workspace)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -196,8 +196,8 @@ func resourceRepositoryUpdate(ctx context.Context, d *schema.ResourceData, m int
 		repoBody := &bitbucket.RepositoriesApiRepositoriesWorkspaceRepoSlugPutOpts{
 			Body: optional.NewInterface(repository),
 		}
-		_, _, err := repoApi.RepositoriesWorkspaceRepoSlugPut(c.AuthContext, repoSlug, workspace, repoBody)
-		if err := handleClientError(err); err != nil {
+		_, res, err := repoApi.RepositoriesWorkspaceRepoSlugPut(c.AuthContext, repoSlug, workspace, repoBody)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -207,8 +207,8 @@ func resourceRepositoryUpdate(ctx context.Context, d *schema.ResourceData, m int
 		if v, ok := d.GetOkExists("pipelines_enabled"); ok {
 			pipelinesConfig := &bitbucket.PipelinesConfig{Enabled: v.(bool)}
 
-			_, _, err := pipeApi.UpdateRepositoryPipelineConfig(c.AuthContext, *pipelinesConfig, workspace, repoSlug)
-			if err := handleClientError(err); err != nil {
+			_, res, err := pipeApi.UpdateRepositoryPipelineConfig(c.AuthContext, *pipelinesConfig, workspace, repoSlug)
+			if err := handleClientError(res, err); err != nil {
 				return diag.FromErr(err)
 			}
 		}
@@ -260,8 +260,8 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, m int
 		Body: optional.NewInterface(repo),
 	}
 
-	_, _, err := repoApi.RepositoriesWorkspaceRepoSlugPost(c.AuthContext, repoSlug, workspace, repoBody)
-	if err := handleClientError(err); err != nil {
+	_, res, err := repoApi.RepositoriesWorkspaceRepoSlugPost(c.AuthContext, repoSlug, workspace, repoBody)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -271,8 +271,8 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, m int
 	if v, ok := d.GetOkExists("pipelines_enabled"); ok {
 		pipelinesConfig := &bitbucket.PipelinesConfig{Enabled: v.(bool)}
 
-		_, _, err = pipeApi.UpdateRepositoryPipelineConfig(c.AuthContext, *pipelinesConfig, workspace, repoSlug)
-		if err := handleClientError(err); err != nil {
+		_, res, err := pipeApi.UpdateRepositoryPipelineConfig(c.AuthContext, *pipelinesConfig, workspace, repoSlug)
+		if err := handleClientError(res, err); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -328,7 +328,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, m inter
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -357,7 +357,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, m inter
 	d.Set("link", flattenLinks(repoRes.Links))
 
 	pipelinesConfigReq, res, err := pipeApi.GetRepositoryPipelineConfig(c.AuthContext, workspace, repoSlug)
-	if err := handleClientError(err); err != nil && res.StatusCode != http.StatusNotFound {
+	if err := handleClientError(res, err); err != nil && res.StatusCode != http.StatusNotFound {
 		return diag.FromErr(err)
 	}
 
@@ -409,8 +409,8 @@ func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, m int
 	c := m.(Clients).genClient
 	repoApi := c.ApiClient.RepositoriesApi
 
-	_, err := repoApi.RepositoriesWorkspaceRepoSlugDelete(c.AuthContext, repoSlug, d.Get("owner").(string), nil)
-	if err := handleClientError(err); err != nil {
+	res, err := repoApi.RepositoriesWorkspaceRepoSlugDelete(c.AuthContext, repoSlug, d.Get("owner").(string), nil)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_repository_variable.go
+++ b/bitbucket/resource_repository_variable.go
@@ -82,8 +82,8 @@ func resourceRepositoryVariableCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	rvRes, _, err := pipeApi.CreateRepositoryPipelineVariable(c.AuthContext, rvcr, workspace, repoSlug)
-	if err := handleClientError(err); err != nil {
+	rvRes, res, err := pipeApi.CreateRepositoryPipelineVariable(c.AuthContext, rvcr, workspace, repoSlug)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -111,7 +111,7 @@ func resourceRepositoryVariableRead(ctx context.Context, d *schema.ResourceData,
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -141,8 +141,8 @@ func resourceRepositoryVariableUpdate(ctx context.Context, d *schema.ResourceDat
 
 	rvcr := newRepositoryVariableFromResource(d)
 
-	_, _, err = pipeApi.UpdateRepositoryPipelineVariable(c.AuthContext, rvcr, workspace, repoSlug, d.Get("uuid").(string))
-	if err := handleClientError(err); err != nil {
+	_, res, err := pipeApi.UpdateRepositoryPipelineVariable(c.AuthContext, rvcr, workspace, repoSlug, d.Get("uuid").(string))
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -159,8 +159,8 @@ func resourceRepositoryVariableDelete(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	_, err = pipeApi.DeleteRepositoryPipelineVariable(c.AuthContext, workspace, repoSlug, d.Get("uuid").(string))
-	if err := handleClientError(err); err != nil {
+	res, err := pipeApi.DeleteRepositoryPipelineVariable(c.AuthContext, workspace, repoSlug, d.Get("uuid").(string))
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_ssh_key.go
+++ b/bitbucket/resource_ssh_key.go
@@ -70,8 +70,8 @@ func resourceSshKeysCreate(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	user := d.Get("user").(string)
-	sshKeyReq, _, err := sshApi.UsersSelectedUserSshKeysPost(c.AuthContext, user, sshKeyBody)
-	if err := handleClientError(err); err != nil {
+	sshKeyReq, res, err := sshApi.UsersSelectedUserSshKeysPost(c.AuthContext, user, sshKeyBody)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -97,7 +97,7 @@ func resourceSshKeysRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -129,8 +129,8 @@ func resourceSshKeysUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(err)
 	}
 
-	_, _, err = sshApi.UsersSelectedUserSshKeysKeyIdPut(c.AuthContext, keyId, user, sshKeyBody)
-	if err := handleClientError(err); err != nil {
+	_, res, err := sshApi.UsersSelectedUserSshKeysKeyIdPut(c.AuthContext, keyId, user, sshKeyBody)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -146,8 +146,8 @@ func resourceSshKeysDelete(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(err)
 	}
 
-	_, err = sshApi.UsersSelectedUserSshKeysKeyIdDelete(c.AuthContext, keyId, user)
-	if err := handleClientError(err); err != nil {
+	res, err := sshApi.UsersSelectedUserSshKeysKeyIdDelete(c.AuthContext, keyId, user)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/bitbucket/resource_workspace_variable.go
+++ b/bitbucket/resource_workspace_variable.go
@@ -76,7 +76,7 @@ func resourceWorkspaceVariableCreate(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[DEBUG] Workspace Variable Create Request Res: %#v", res)
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -104,7 +104,7 @@ func resourceWorkspaceVariableRead(ctx context.Context, d *schema.ResourceData, 
 		return nil
 	}
 
-	if err := handleClientError(err); err != nil {
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -133,8 +133,8 @@ func resourceWorkspaceVariableUpdate(ctx context.Context, d *schema.ResourceData
 
 	rvcr := newWorkspaceVariableFromResource(d)
 
-	_, _, err = pipeApi.UpdatePipelineVariableForWorkspace(c.AuthContext, rvcr, workspace, uuid)
-	if err := handleClientError(err); err != nil {
+	_, res, err := pipeApi.UpdatePipelineVariableForWorkspace(c.AuthContext, rvcr, workspace, uuid)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -150,8 +150,8 @@ func resourceWorkspaceVariableDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	_, err = pipeApi.DeletePipelineVariableForWorkspace(c.AuthContext, workspace, uuid)
-	if err := handleClientError(err); err != nil {
+	res, err := pipeApi.DeletePipelineVariableForWorkspace(c.AuthContext, workspace, uuid)
+	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
This PR makes sure that an authorization error (`401 Unauthorized`) is at least shown to the end user.

---

Bitbucket responses, mainly headers and error codes, seem to have completely changed. For the unauthorized response, the `Content-Type` was changed to `"text/plain"` where no HTTP-body is returned any more.

Because of this, the client's decoding fails (see https://github.com/DrFaust92/bitbucket-go-client/blob/main/client.go#L387), and the original Bitbucket API error is no longer passed to the Terraform code.

To overcome this issue, I now rely on the raw HTTP Response and always log the original HTTP Code. The main files to review are the tests and the `bitbucket/error.go` file.

**Authorization error**
```
╷
│ Error: 401 Unauthorized: 
│ 
│   with bitbucket_repository.that,
│   on example.tf line 13, in resource "bitbucket_repository" "that":
│   13: resource "bitbucket_repository" "that" {
│ 
```

**Other Bitbucket API error**
```
╷
│ Error: 400 Bad Request: Repository with this Slug and Owner already exists.
│ 
│   with bitbucket_repository.that,
│   on example.tf line 13, in resource "bitbucket_repository" "that":
│   13: resource "bitbucket_repository" "that" {
│ 
╵
```

----
I ran the acceptance tests, but found some issues that also happen on the master branch. 

An individual run, for example for the Bitbucket Repository resource, shows an error that is not caused by this PR:
```
?       github.com/terraform-providers/terraform-provider-bitbucket     [no test files]
=== RUN   TestAccBitbucketRepositoryGroupPermission_basic
--- PASS: TestAccBitbucketRepositoryGroupPermission_basic (19.98s)
=== RUN   TestAccBitbucketRepository_basic
--- PASS: TestAccBitbucketRepository_basic (9.63s)
=== RUN   TestAccBitbucketRepository_project
--- PASS: TestAccBitbucketRepository_project (10.74s)
=== RUN   TestAccBitbucketRepository_avatar
--- PASS: TestAccBitbucketRepository_avatar (9.26s)
=== RUN   TestAccBitbucketRepository_slug
--- PASS: TestAccBitbucketRepository_slug (8.16s)
=== RUN   TestAccBitbucketRepository_inherit
--- PASS: TestAccBitbucketRepository_inherit (22.73s)
=== RUN   TestAccBitbucketRepository_wrongCredential
--- PASS: TestAccBitbucketRepository_wrongCredential (0.71s)
=== RUN   TestAccBitbucketRepository_duplicate
--- PASS: TestAccBitbucketRepository_duplicate (5.49s)
=== RUN   TestAccBitbucketRepositoryUserPermission_basic
--- FAIL: TestAccBitbucketRepositoryUserPermission_basic (7.14s)
=== RUN   TestAccBitbucketRepositoryVariable_basic
--- PASS: TestAccBitbucketRepositoryVariable_basic (15.43s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-bitbucket/bitbucket   109.292s
FAIL
```

Manual tested a correct apply, authorization error and a Bitbucket API error.