### PR TITLE
chore(doc): extend branch-restriction documentation example to show username usage

### DIFF
--- a/docs/resources/branch_restriction.md
+++ b/docs/resources/branch_restriction.md
@@ -24,6 +24,8 @@ resource "bitbucket_branch_restriction" "master" {
   kind = "push"
   pattern = "master"
   
+  users = [ "my-bitbucket-username" ]
+
   groups {
     slug = "my-group"
     owner = "my-owner"


### PR DESCRIPTION
A small PR to show that users use Bitbucket usernames, instead of `uuid`s.

Closes #53 