### PR TITLE
Prevent using user name with bitbucket_repository_user_permission. Must be UUID.

### DIFF
--- a/bitbucket/resource_repository_user_permission.go
+++ b/bitbucket/resource_repository_user_permission.go
@@ -105,6 +105,10 @@ func resourceRepositoryUserPermissionPut(ctx context.Context, d *schema.Resource
 		d.SetId(fmt.Sprintf("%s:%s:%s", workspace, repoSlug, userSlug))
 	}
 
+	if userSlug != permission.User.UUID {
+		return diag.FromErr(fmt.Errorf("The user_id must be a UUID, but a user name was given (\"%s\"). The UUID for this user is \"%s\".", userSlug, permission.User.UUID))
+	}
+
 	return resourceRepositoryUserPermissionRead(ctx, d, m)
 }
 


### PR DESCRIPTION
This fixes a nuisance issue I noticed. With `bitbucket_repository_user_permission`, if `user_id` is a user _name_ (rather than a UUID), the changes apply without error, but subsequent runs of `terraform plan` and `terraform apply` always show a change needs to be applied.

I noticed that the provider [documentation](https://registry.terraform.io/providers/DrFaust92/bitbucket/latest/docs/resources/repository_user_permission#argument-reference) explicitly states that `user_id` is "The UUID of the user.", so it seems best to disallow the use of user names. This PR does that. As a bonus, the error message provides the UUID of the user to make it easy to fix the code.

```
  user_permissions = {
    "my-user-name" = "write",
    # Should be a UUID
  "{aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa}" = "write",
  }
```