### PR TITLE
Use more consistent endpoint for project branching models

### DIFF
--- a/bitbucket/resource_project_branching_model.go
+++ b/bitbucket/resource_project_branching_model.go
@@ -160,7 +160,7 @@ func resourceProjectBranchingModelsRead(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	branchingModelsReq, _ := client.Get(fmt.Sprintf("2.0/workspaces/%s/projects/%s/branching-model", workspace, repo))
+	branchingModelsReq, _ := client.Get(fmt.Sprintf("2.0/workspaces/%s/projects/%s/branching-model/settings", workspace, repo))
 
 	if branchingModelsReq.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Project Branching Model (%s) not found, removing from state", d.Id())


### PR DESCRIPTION
As per: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-branching-model/#api-repositories-workspace-repo-slug-branching-model-settings-get

`projects/PROJECT/branching-model/settings` will return more consistent results compared to `projects/PROJECT/branching-model`.

For the same repo (no settings changed):

`projects/PROJECT/branching-model/settings`
```
{"type": "branching_model_settings", "links": {"self": {"href": "https://api.bitbucket.org/2.0/workspaces/MY_ORG/projects/MY_PROJECT/branching-model/settings"}}, "branch_types": [{"enabled": true, "kind": "release", "prefix": "release/"}, {"enabled": true, "kind": "hotfix", "prefix": "hotfix/"}, {"enabled": false, "kind": "feature", "prefix": "feature/"}, {"enabled": true, "kind": "bugfix", "prefix": "bugfix/"}], "development": {"name": "develop", "use_mainbranch": false}, "production": {"name": null, "use_mainbranch": true, "enabled": false}}
```

`projects/PROJECT/branching-mode`
```
{"type": "project_branching_model", "links": {"self": {"href": "https://api.bitbucket.org/2.0/workspaces/MY_ORG/projects/MY_PROJECT/branching-model"}}, "branch_types": [{"kind": "release", "prefix": "release/"}, {"kind": "hotfix", "prefix": "hotfix/"}, {"kind": "bugfix", "prefix": "bugfix/"}], "development": {"name": "develop", "use_mainbranch": false}}
```

As a result of using the more consistent API endpoint, perma-diffing is solved - and there is no loss of functionality otherwise