### PR TITLE
feat: allow addressing deployment additionally by name

### DIFF
--- a/bitbucket/data_deployment.go
+++ b/bitbucket/data_deployment.go
@@ -47,10 +47,29 @@ func dataReadDeployment(ctx context.Context, d *schema.ResourceData, m interface
 	workspace := d.Get("workspace").(string)
 	repoId := d.Get("repository").(string)
 
+	c1 := m.(Clients).genClient
+	deployApi := c1.ApiClient.DeploymentsApi
+	deploymentsResp, res1, err1 := deployApi.GetEnvironmentsForRepository(c1.AuthContext, workspace, repoId, nil)
+	if err1 := handleClientError(res1, err1); err1 != nil {
+		return diag.FromErr(err1)
+	}
+	deployments := deploymentsResp.Values
+
+    // uuid can be set to either the deployment uuid or the deployment name
+    // this is especially useful in cases when we want to use existing deployments (e.g. prod), where we don't have
+    // control over the uuid and we currently have no means to get hold of that uuid
+	var uuid string
+	for _, deployment := range deployments {
+		if deployment.Uuid == d.Get("uuid").(string) || deployment.Name == d.Get("uuid").(string) {
+			uuid = deployment.Uuid
+			break
+		}
+	}
+
 	res, err := c.Get(fmt.Sprintf("2.0/repositories/%s/%s/environments/%s",
 		workspace,
 		repoId,
-		d.Get("uuid").(string),
+		uuid,
 	))
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
Previously only uuid was possible.