### PR TITLE
Improve oauth error handling

### DIFF
--- a/bitbucket/error.go
+++ b/bitbucket/error.go
@@ -6,23 +6,31 @@ import (
 	"net/http"
 
 	"github.com/DrFaust92/bitbucket-go-client"
+	"golang.org/x/oauth2"
 )
 
+type ClientScopeError struct {
+	Error struct {
+		Message string `json:"message"`
+		Detail  struct {
+			Required []string `json:"required"`
+			Granted  []string `json:"granted"`
+		} `json:"detail"`
+	} `json:"error"`
+}
+
 func handleClientError(httpResponse *http.Response, err error) error {
+	if oauthError, ok := err.(*oauth2.RetrieveError); ok {
+		return fmt.Errorf("%s: %s", oauthError.Response.Status, oauthError.ErrorDescription)
+	}
+
 	if httpResponse == nil || httpResponse.StatusCode < 400 {
 		return nil
 	}
 
 	clientHttpError, ok := err.(bitbucket.GenericSwaggerError)
 	if ok {
-		var errorBody string
-		var bitbucketHttpError bitbucket.ModelError
-		if err := json.Unmarshal(clientHttpError.Body(), &bitbucketHttpError); err != nil {
-			errorBody = string(clientHttpError.Body()[:])
-		} else {
-			errorBody = bitbucketHttpError.Error_.Message
-		}
-
+		errorBody := extractErrorMessage(clientHttpError.Body())
 		return fmt.Errorf("%s: %s", httpResponse.Status, errorBody)
 	}
 
@@ -31,4 +39,21 @@ func handleClientError(httpResponse *http.Response, err error) error {
 	}
 
 	return nil
+}
+
+func extractErrorMessage(body []byte) string {
+	var bitbucketHttpError bitbucket.ModelError
+	if err := json.Unmarshal(body, &bitbucketHttpError); err == nil {
+		return bitbucketHttpError.Error_.Message
+	}
+
+	var clientScopeErr ClientScopeError
+	if err := json.Unmarshal(body, &clientScopeErr); err == nil {
+		message := clientScopeErr.Error.Message
+		required := clientScopeErr.Error.Detail.Required
+		granted := clientScopeErr.Error.Detail.Granted
+		return fmt.Sprintf("%s Required: %v Granted: %v", message, required, granted)
+	}
+
+	return string(body[:])
 }

--- a/bitbucket/resource_deploy_key.go
+++ b/bitbucket/resource_deploy_key.go
@@ -107,7 +107,7 @@ func resourceDeployKeysRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	deployKey, res, err := deployApi.RepositoriesWorkspaceRepoSlugDeployKeysKeyIdGet(c.AuthContext, keyId, repo, workspace)
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Deploy Key (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_deployment_variable.go
+++ b/bitbucket/resource_deployment_variable.go
@@ -107,7 +107,7 @@ func resourceDeploymentVariableRead(ctx context.Context, d *schema.ResourceData,
 
 	rvRes, res, err := pipeApi.GetDeploymentVariables(c.AuthContext, workspace, repoSlug, deployment, nil)
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Deployment Variable (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_forked_repository.go
+++ b/bitbucket/resource_forked_repository.go
@@ -267,7 +267,7 @@ func resourceForkedRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 
 	repoRes, res, err := repoApi.RepositoriesWorkspaceRepoSlugGet(c.AuthContext, repoSlug, workspace)
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Repository (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_pipeline_schedule.go
+++ b/bitbucket/resource_pipeline_schedule.go
@@ -150,7 +150,7 @@ func resourcePipelineScheduleRead(ctx context.Context, d *schema.ResourceData, m
 
 	schedule, res, err := pipeApi.GetRepositoryPipelineSchedule(c.AuthContext, workspace, repo, uuid)
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Pipeline Schedule (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_pipeline_ssh_key.go
+++ b/bitbucket/resource_pipeline_ssh_key.go
@@ -75,7 +75,7 @@ func resourcePipelineSshKeysRead(ctx context.Context, d *schema.ResourceData, m 
 
 	key, res, err := pipeApi.GetRepositoryPipelineSshKeyPair(c.AuthContext, workspace, repo)
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Pipeline Ssh Key (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_pipeline_ssh_known_host.go
+++ b/bitbucket/resource_pipeline_ssh_known_host.go
@@ -121,7 +121,7 @@ func resourcePipelineSshKnownHostsRead(ctx context.Context, d *schema.ResourceDa
 
 	host, res, err := pipeApi.GetRepositoryPipelineKnownHost(c.AuthContext, workspace, repo, uuid)
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Pipeline Ssh known host (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_project.go
+++ b/bitbucket/resource_project.go
@@ -198,7 +198,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	projRes, res, err := projectApi.WorkspacesWorkspaceProjectsProjectKeyGet(c.AuthContext, projectKey, d.Get("owner").(string))
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Project (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -345,7 +345,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	repoRes, res, err := repoApi.RepositoriesWorkspaceRepoSlugGet(c.AuthContext, repoSlug, workspace)
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Repository (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_repository_variable.go
+++ b/bitbucket/resource_repository_variable.go
@@ -105,7 +105,7 @@ func resourceRepositoryVariableRead(ctx context.Context, d *schema.ResourceData,
 
 	rvRes, res, err := pipeApi.GetRepositoryPipelineVariable(c.AuthContext, workspace, repoSlug, d.Get("uuid").(string))
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Repository Variable (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_ssh_key.go
+++ b/bitbucket/resource_ssh_key.go
@@ -91,7 +91,7 @@ func resourceSshKeysRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	sshKeyReq, res, err := sshApi.UsersSelectedUserSshKeysKeyIdGet(c.AuthContext, keyId, user)
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] SSH Key (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil

--- a/bitbucket/resource_workspace_variable.go
+++ b/bitbucket/resource_workspace_variable.go
@@ -98,7 +98,7 @@ func resourceWorkspaceVariableRead(ctx context.Context, d *schema.ResourceData, 
 
 	log.Printf("[DEBUG] Workspace Variable Get Request Res: %#v", res)
 
-	if res.StatusCode == http.StatusNotFound {
+	if res != nil && res.StatusCode == http.StatusNotFound {
 		log.Printf("[WARN] Workspace Variable (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil


### PR DESCRIPTION
This PR addresses a few issues I've experienced with the provider when using OAuth. Currently, most OAuth related errors result in a panic and the provider crashing. This can be replicated on the current version by doing the following:
- Using the key/secret of an OAuth provider which doesn't have a callback URL defined
- Using the key/secret of an OAuth provider which doesn't have the "This is a private consumer" option ticked
- Running `terraform apply` using incorrect OAuth credentials
- Running `terraform plan` using incorrect OAuth credentials when there is at least 1 bitbucket resource in the state

This is the result of a number of resources referencing `res.StatusCode` after making an API call which can return a nil http response. I've currently fixed this by just adding a nil check, but also can be fixed by checking the error first with the `handleClientError` block. There are occurrences of both of these approaches in other files - I've stuck with the nil check as I'm not sure if there is intended behaviour I'm not aware of where there may be an error returned but the status code should still be checked to remove a resource from state. 

Since the http response is nil and OAuth fails the `bitbucket.GenericSwaggerError` type assertion, a new check was required in `handleClientError` to properly pick up the error. 

These errors are now bubbled back up to the user. Below is an example of the error for invalid credentials.

```
bitbucket_project.test_project: Creating...
╷
│ Error: 400 Bad Request: Invalid OAuth client credentials
│ 
│   with bitbucket_project.test_project,
│   on main.tf line 27, in resource "bitbucket_project" "test_project":
│   27: resource "bitbucket_project" "test_project" {
│ 
╵
```

After fixing this, I noticed that the response format for account permission scoping errors does not match the `bitbucket.ModelError` type, which results in a stringified json in the error output. I've added a new type to capture this, and outputs as below. I'm open to input on the formatting here.

```
bitbucket_project.test_project: Creating...
╷
│ Error: 403 Forbidden: Your credentials lack one or more required privilege scopes. Required: [project:admin] Granted: [pipeline webhook repository:delete repository:admin repository:write project team:write]
│ 
│   with bitbucket_project.test_project,
│   on main.tf line 27, in resource "bitbucket_project" "test_project":
│   27: resource "bitbucket_project" "test_project" {
│ 
╵
```

Please let me know if there should be additions to the docs to clarify some of the OAuth setup items (callback url, private consumer). I feel like since the user gets a readable error now it should be enough for them to fix anything they come across.