### PR TITLE
fix: handle string-typed default_branch_deletion from Bitbucket API

### DIFF
--- a/bitbucket/flex_bool.go
+++ b/bitbucket/flex_bool.go
@@ -1,0 +1,53 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// FlexBool is a bool type that can be unmarshaled from both JSON boolean and
+// JSON string representations (e.g. true, "true", "false").
+// This is needed because the Bitbucket API inconsistently returns some boolean
+// fields as strings (e.g. "default_branch_deletion": "false").
+type FlexBool struct {
+	Value *bool
+}
+
+func (fb *FlexBool) UnmarshalJSON(data []byte) error {
+	// Try bool first
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		fb.Value = &b
+		return nil
+	}
+
+	// Try string
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		parsed, err := strconv.ParseBool(s)
+		if err != nil {
+			return err
+		}
+		fb.Value = &parsed
+		return nil
+	}
+
+	// null
+	fb.Value = nil
+	return nil
+}
+
+func (fb FlexBool) MarshalJSON() ([]byte, error) {
+	if fb.Value == nil {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(*fb.Value)
+}
+
+// BoolPtr returns the underlying *bool value.
+func (fb *FlexBool) BoolPtr() *bool {
+	if fb == nil {
+		return nil
+	}
+	return fb.Value
+}

--- a/bitbucket/flex_bool_test.go
+++ b/bitbucket/flex_bool_test.go
@@ -1,0 +1,119 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFlexBool_UnmarshalJSON_BoolTrue(t *testing.T) {
+	input := []byte(`{"default_branch_deletion": true}`)
+	var result struct {
+		DefaultBranchDeletion *FlexBool `json:"default_branch_deletion"`
+	}
+	if err := json.Unmarshal(input, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranchDeletion == nil || result.DefaultBranchDeletion.Value == nil {
+		t.Fatal("expected non-nil value")
+	}
+	if *result.DefaultBranchDeletion.Value != true {
+		t.Fatalf("expected true, got %v", *result.DefaultBranchDeletion.Value)
+	}
+}
+
+func TestFlexBool_UnmarshalJSON_BoolFalse(t *testing.T) {
+	input := []byte(`{"default_branch_deletion": false}`)
+	var result struct {
+		DefaultBranchDeletion *FlexBool `json:"default_branch_deletion"`
+	}
+	if err := json.Unmarshal(input, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranchDeletion == nil || result.DefaultBranchDeletion.Value == nil {
+		t.Fatal("expected non-nil value")
+	}
+	if *result.DefaultBranchDeletion.Value != false {
+		t.Fatalf("expected false, got %v", *result.DefaultBranchDeletion.Value)
+	}
+}
+
+func TestFlexBool_UnmarshalJSON_StringTrue(t *testing.T) {
+	input := []byte(`{"default_branch_deletion": "true"}`)
+	var result struct {
+		DefaultBranchDeletion *FlexBool `json:"default_branch_deletion"`
+	}
+	if err := json.Unmarshal(input, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranchDeletion == nil || result.DefaultBranchDeletion.Value == nil {
+		t.Fatal("expected non-nil value")
+	}
+	if *result.DefaultBranchDeletion.Value != true {
+		t.Fatalf("expected true, got %v", *result.DefaultBranchDeletion.Value)
+	}
+}
+
+func TestFlexBool_UnmarshalJSON_StringFalse(t *testing.T) {
+	input := []byte(`{"default_branch_deletion": "false"}`)
+	var result struct {
+		DefaultBranchDeletion *FlexBool `json:"default_branch_deletion"`
+	}
+	if err := json.Unmarshal(input, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranchDeletion == nil || result.DefaultBranchDeletion.Value == nil {
+		t.Fatal("expected non-nil value")
+	}
+	if *result.DefaultBranchDeletion.Value != false {
+		t.Fatalf("expected false, got %v", *result.DefaultBranchDeletion.Value)
+	}
+}
+
+func TestFlexBool_UnmarshalJSON_Null(t *testing.T) {
+	input := []byte(`{"default_branch_deletion": null}`)
+	var result struct {
+		DefaultBranchDeletion *FlexBool `json:"default_branch_deletion"`
+	}
+	if err := json.Unmarshal(input, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranchDeletion == nil {
+		// json.Unmarshal with null sets the pointer to nil
+		return
+	}
+	if result.DefaultBranchDeletion.Value != nil {
+		t.Fatalf("expected nil value, got %v", *result.DefaultBranchDeletion.Value)
+	}
+}
+
+func TestFlexBool_UnmarshalJSON_Absent(t *testing.T) {
+	input := []byte(`{}`)
+	var result struct {
+		DefaultBranchDeletion *FlexBool `json:"default_branch_deletion"`
+	}
+	if err := json.Unmarshal(input, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranchDeletion != nil {
+		t.Fatalf("expected nil, got %v", result.DefaultBranchDeletion)
+	}
+}
+
+func TestFlexBool_MarshalJSON(t *testing.T) {
+	val := true
+	fb := FlexBool{Value: &val}
+	data, err := json.Marshal(fb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "true" {
+		t.Fatalf("expected 'true', got %s", string(data))
+	}
+}
+
+func TestFlexBool_BoolPtr_Nil(t *testing.T) {
+	var fb *FlexBool
+	if fb.BoolPtr() != nil {
+		t.Fatal("expected nil")
+	}
+}

--- a/bitbucket/resource_branching_model.go
+++ b/bitbucket/resource_branching_model.go
@@ -20,7 +20,7 @@ type BranchingModel struct {
 	Development           *BranchModel  `json:"development,omitempty"`
 	Production            *BranchModel  `json:"production,omitempty"`
 	BranchTypes           []*BranchType `json:"branch_types"`
-	DefaultBranchDeletion *bool         `json:"default_branch_deletion,omitempty"`
+	DefaultBranchDeletion *FlexBool `json:"default_branch_deletion,omitempty"`
 }
 
 type BranchModel struct {
@@ -226,7 +226,7 @@ func resourceBranchingModelsRead(ctx context.Context, d *schema.ResourceData, m 
 
 	d.Set("owner", owner)
 	d.Set("repository", repo)
-	d.Set("default_branch_deletion", branchingModel.DefaultBranchDeletion)
+	d.Set("default_branch_deletion", branchingModel.DefaultBranchDeletion.BoolPtr())
 	d.Set("development", flattenBranchModel(branchingModel.Development, "development"))
 	d.Set("branch_type", flattenBranchTypes(branchingModel.BranchTypes))
 	d.Set("production", flattenBranchModel(branchingModel.Production, "production"))
@@ -270,7 +270,8 @@ func expandBranchingModel(d *schema.ResourceData) *BranchingModel {
 
 	//nolint:staticcheck
 	if v, ok := d.GetOkExists("default_branch_deletion"); ok {
-		model.DefaultBranchDeletion = v.(*bool)
+		val := v.(bool)
+		model.DefaultBranchDeletion = &FlexBool{Value: &val}
 	}
 
 	return model

--- a/bitbucket/resource_branching_model.go
+++ b/bitbucket/resource_branching_model.go
@@ -20,7 +20,7 @@ type BranchingModel struct {
 	Development           *BranchModel  `json:"development,omitempty"`
 	Production            *BranchModel  `json:"production,omitempty"`
 	BranchTypes           []*BranchType `json:"branch_types"`
-	DefaultBranchDeletion *FlexBool `json:"default_branch_deletion,omitempty"`
+	DefaultBranchDeletion *FlexBool     `json:"default_branch_deletion,omitempty"`
 }
 
 type BranchModel struct {


### PR DESCRIPTION
## Problem

Fixes #234

The Bitbucket Cloud API returns the `default_branch_deletion` field as a JSON **string** (e.g. `"false"`) instead of a native boolean in the branching model settings endpoint. This causes `json.Unmarshal` to fail with:

```
Error: json: cannot unmarshal string into Go struct field BranchingModel.default_branch_deletion of type bool
```

This breaks `terraform import`, `terraform plan`, `terraform apply`, and `terraform refresh` for both `bitbucket_project_branching_model` and `bitbucket_branching_model` resources.

Reference: https://community.atlassian.com/forums/Bitbucket-questions/How-can-I-set-this-option-to-delete-source-branch-on-a-pull/qaq-p/2991862

## Solution

Introduce a `FlexBool` type that implements custom JSON marshaling and correctly handles both boolean (`true`/`false`) and string (`"true"`/`"false"`) representations from the API.

### Changes

- `bitbucket/flex_bool.go` — New `FlexBool` type with `UnmarshalJSON`, `MarshalJSON`, and `BoolPtr()` helper
- `bitbucket/flex_bool_test.go` — Unit tests covering bool, string, null, and absent values
- `bitbucket/resource_branching_model.go` — Updated `BranchingModel.DefaultBranchDeletion` from `*bool` to `*FlexBool`

## Testing

- All new unit tests pass (`go test ./bitbucket/ -run TestFlexBool`)
- Verified locally: `terraform plan -refresh=true` succeeds for `bitbucket_project_branching_model`
- Verified locally: `terraform import` succeeds for `bitbucket_project_branching_model`

---

Co-authored-by: Kiro AI <noreply@kiro.dev>