### PR TITLE
Add bitbucket_gpg_key resource

### DIFF
--- a/bitbucket/provider.go
+++ b/bitbucket/provider.go
@@ -76,6 +76,7 @@ func Provider() *schema.Provider {
 			"bitbucket_deployment":                  resourceDeployment(),
 			"bitbucket_deployment_variable":         resourceDeploymentVariable(),
 			"bitbucket_forked_repository":           resourceForkedRepository(),
+			"bitbucket_gpg_key":                     resourceGpgKey(),
 			"bitbucket_group":                       resourceGroup(),
 			"bitbucket_group_membership":            resourceGroupMembership(),
 			"bitbucket_hook":                        resourceHook(),

--- a/bitbucket/resource_gpg_key.go
+++ b/bitbucket/resource_gpg_key.go
@@ -1,0 +1,145 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/DrFaust92/bitbucket-go-client"
+	"github.com/antihax/optional"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceGpgKey() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceGpgKeysCreate,
+		ReadWithoutTimeout:   resourceGpgKeysRead,
+		DeleteWithoutTimeout: resourceGpgKeysDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"user": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fingerprint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGpgKeysCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(Clients).genClient
+	gpgApi := c.ApiClient.GPGApi
+
+	gpgKey := expandGpgKey(d)
+
+	gpgKeyBody := &bitbucket.GPGApiUsersSelectedUserGpgKeysPostOpts{
+		Body: optional.NewInterface(gpgKey),
+	}
+
+	user := d.Get("user").(string)
+	gpgKeyReq, res, err := gpgApi.UsersSelectedUserGpgKeysPost(c.AuthContext, user, gpgKeyBody)
+	if err := handleClientError(res, err); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", user, gpgKeyReq.Fingerprint))
+
+	return resourceGpgKeysRead(ctx, d, m)
+}
+
+func resourceGpgKeysRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(Clients).genClient
+	gpgApi := c.ApiClient.GPGApi
+
+	user, fingerprint, err := gpgKeyId(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	gpgKeyReq, res, err := gpgApi.UsersSelectedUserGpgKeysFingerprintGet(c.AuthContext, fingerprint, user)
+
+	if res != nil && res.StatusCode == http.StatusNotFound {
+		log.Printf("[WARN] GPG Key (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err := handleClientError(res, err); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if res.Body == nil {
+		return diag.Errorf("error getting GPG Key (%s): empty response", d.Id())
+	}
+
+	d.Set("user", user)
+	// The API returns the normalized (armored) key, which differs from the
+	// submitted value; preserve the configured key to avoid a perpetual diff.
+	d.Set("key", d.Get("key").(string))
+	d.Set("name", gpgKeyReq.Name)
+	d.Set("fingerprint", gpgKeyReq.Fingerprint)
+	d.Set("key_id", gpgKeyReq.KeyId)
+
+	return nil
+}
+
+func resourceGpgKeysDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(Clients).genClient
+	gpgApi := c.ApiClient.GPGApi
+
+	user, fingerprint, err := gpgKeyId(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	res, err := gpgApi.UsersSelectedUserGpgKeysFingerprintDelete(c.AuthContext, fingerprint, user)
+	if err := handleClientError(res, err); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func expandGpgKey(d *schema.ResourceData) *bitbucket.GpgAccountKey {
+	key := &bitbucket.GpgAccountKey{
+		Key:  d.Get("key").(string),
+		Name: d.Get("name").(string),
+	}
+
+	return key
+}
+
+func gpgKeyId(id string) (string, string, error) {
+	parts := strings.Split(id, "/")
+
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unexpected format of ID (%q), expected USER-ID/FINGERPRINT", id)
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/bitbucket/resource_gpg_key_test.go
+++ b/bitbucket/resource_gpg_key_test.go
@@ -1,0 +1,164 @@
+package bitbucket
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// randGPGPublicKey generates a fresh ASCII-armored GPG public key so each
+// acceptance run uses a unique fingerprint (Bitbucket rejects duplicates).
+func randGPGPublicKey(name, email string) (string, error) {
+	entity, err := openpgp.NewEntity(name, "terraform-acctest", email, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		return "", err
+	}
+	if err := entity.Serialize(w); err != nil {
+		return "", err
+	}
+	if err := w.Close(); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func TestAccBitbucketGpgKey_basic(t *testing.T) {
+	resourceName := "bitbucket_gpg_key.test"
+
+	userEmail := os.Getenv("BITBUCKET_USERNAME")
+	publicKey, err := randGPGPublicKey("tf-acctest", userEmail)
+	if err != nil {
+		t.Fatalf("error generating GPG key: %s", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBitbucketGpgKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBitbucketGpgKeyConfig(publicKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBitbucketGpgKeyExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "user", "data.bitbucket_current_user.test", "uuid"),
+					resource.TestCheckResourceAttr(resourceName, "key", publicKey),
+					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
+					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key"},
+			},
+		},
+	})
+}
+
+func TestAccBitbucketGpgKey_name(t *testing.T) {
+	resourceName := "bitbucket_gpg_key.test"
+
+	rName := acctest.RandomWithPrefix("tf-test")
+	userEmail := os.Getenv("BITBUCKET_USERNAME")
+	publicKey, err := randGPGPublicKey("tf-acctest", userEmail)
+	if err != nil {
+		t.Fatalf("error generating GPG key: %s", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBitbucketGpgKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBitbucketGpgKeyNameConfig(publicKey, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBitbucketGpgKeyExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "user", "data.bitbucket_current_user.test", "uuid"),
+					resource.TestCheckResourceAttr(resourceName, "key", publicKey),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key"},
+			},
+		},
+	})
+}
+
+func testAccCheckBitbucketGpgKeyDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(Clients).genClient
+	gpgApi := client.ApiClient.GPGApi
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "bitbucket_gpg_key" {
+			continue
+		}
+
+		user, fingerprint, err := gpgKeyId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, res, _ := gpgApi.UsersSelectedUserGpgKeysFingerprintGet(client.AuthContext, fingerprint, user)
+		if res.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("GPG Key still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckBitbucketGpgKeyExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No GPG Key ID is set")
+		}
+		return nil
+	}
+}
+
+func testAccBitbucketGpgKeyConfig(pubkey string) string {
+	return fmt.Sprintf(`
+data "bitbucket_current_user" "test" {}
+
+resource "bitbucket_gpg_key" "test" {
+  user = data.bitbucket_current_user.test.uuid
+  key  = %[1]q
+}
+`, pubkey)
+}
+
+func testAccBitbucketGpgKeyNameConfig(pubkey, name string) string {
+	return fmt.Sprintf(`
+data "bitbucket_current_user" "test" {}
+
+resource "bitbucket_gpg_key" "test" {
+  user = data.bitbucket_current_user.test.uuid
+  key  = %[1]q
+  name = %[2]q
+}
+`, pubkey, name)
+}

--- a/docs/resources/gpg_key.md
+++ b/docs/resources/gpg_key.md
@@ -1,0 +1,47 @@
+---
+layout: "bitbucket"
+page_title: "Bitbucket: bitbucket_gpg_key"
+sidebar_current: "docs-bitbucket-resource-gpg-key"
+description: |-
+  Provides a Bitbucket GPG Key
+---
+
+# bitbucket\_gpg\_key
+
+Provides a Bitbucket GPG Key resource.
+
+This allows you to manage your GPG Keys for a user.
+
+* OAuth2 Scopes: `account` and `account:write`
+* API token permissions: `read:gpg-key:bitbucket`, `write:gpg-key:bitbucket`, and `delete:gpg-key:bitbucket`
+
+## Example Usage
+
+```hcl
+resource "bitbucket_gpg_key" "test" {
+  user = data.bitbucket_current_user.test.uuid
+  key  = file("pubkey.asc")
+  name = "test-key"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `user` - (Required) This can either be the UUID of the account, surrounded by curly-braces, for example: {account UUID}, OR an Atlassian Account ID.
+* `key` - (Required) The GPG public key value in ASCII-armored format.
+* `name` - (Optional) The user-defined label for the GPG key.
+
+## Attributes Reference
+
+* `fingerprint` - The GPG key fingerprint.
+* `key_id` - The unique identifier for the GPG key.
+
+## Import
+
+GPG Keys can be imported using their `user/fingerprint` ID, e.g.
+
+```sh
+terraform import bitbucket_gpg_key.test user-id/fingerprint
+```

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/terraform-providers/terraform-provider-bitbucket
 
 require (
 	github.com/DrFaust92/bitbucket-go-client v0.11.0
+	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/antihax/optional v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/satori/go.uuid v1.2.0
@@ -10,7 +11,6 @@ require (
 )
 
 require (
-	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect


### PR DESCRIPTION
Adds a `bitbucket_gpg_key` resource for managing a user's GPG keys, using the GPG endpoints that landed in `bitbucket-go-client` v0.11.0.

### Behavior
Mirrors `bitbucket_ssh_key`, with two differences dictated by the API:
- keys are addressed by **fingerprint** → resource id is `user/fingerprint`
- the GPG endpoint has **no update** operation → all fields are `ForceNew`

### Schema
- `user` (Required, ForceNew) — account UUID or Atlassian Account ID
- `key` (Required, ForceNew) — ASCII-armored GPG public key
- `name` (Optional, ForceNew) — user-defined label
- `fingerprint`, `key_id` (Computed)

### Included
- resource + provider registration
- docs (`docs/resources/gpg_key.md`)
- acceptance test — generates a fresh armored GPG key per run (via `ProtonMail/go-crypto`, test-scoped) so runs don't collide on fingerprint

### Verification
Verified offline:
- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run` — 0 issues
- GPG key generation validated (produces a valid, re-parseable armored public key)

> ⚠️ **Best effort — acceptance test not run.** It requires `TF_ACC` + live Bitbucket credentials, which I don't have access to. A maintainer with a Bitbucket account should run `TF_ACC=1 go test ./bitbucket/ -run TestAccBitbucketGpgKey` before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)