### PR TITLE
Fixed user handling in branch restrictions

### DIFF
--- a/bitbucket/resource_branch_restriction.go
+++ b/bitbucket/resource_branch_restriction.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/DrFaust92/bitbucket-go-client"
+	"github.com/antihax/optional"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -136,18 +137,7 @@ func resourceBranchRestriction() *schema.Resource {
 	}
 }
 
-func createBranchRestriction(d *schema.ResourceData) *bitbucket.Branchrestriction {
-
-	users := make([]bitbucket.Account, 0, d.Get("users").(*schema.Set).Len())
-
-	for _, item := range d.Get("users").(*schema.Set).List() {
-		account := bitbucket.Account{
-			Username: item.(string),
-		}
-
-		users = append(users, account)
-	}
-
+func createBranchRestriction(d *schema.ResourceData, users []bitbucket.Account) *bitbucket.Branchrestriction {
 	groups := make([]bitbucket.Group, 0, d.Get("groups").(*schema.Set).Len())
 
 	for _, item := range d.Get("groups").(*schema.Set).List() {
@@ -187,13 +177,59 @@ func createBranchRestriction(d *schema.ResourceData) *bitbucket.Branchrestrictio
 	return restict
 }
 
+func branchRestrictionUsers(c ProviderConfig, workspace string, displayNames *schema.Set) ([]bitbucket.Account, error) {
+	if displayNames.Len() == 0 {
+		return nil, nil
+	}
+
+	workspaceAPI := c.ApiClient.WorkspacesApi
+	memberUUIDs := make(map[string]string)
+	options := bitbucket.WorkspacesApiWorkspacesWorkspaceMembersGetOpts{}
+
+	for {
+		workspaceMembers, res, err := workspaceAPI.WorkspacesWorkspaceMembersGet(c.AuthContext, workspace, &options)
+		if err := handleClientError(res, err); err != nil {
+			return nil, err
+		}
+
+		for _, member := range workspaceMembers.Values {
+			if member.User != nil {
+				memberUUIDs[member.User.DisplayName] = member.User.Uuid
+			}
+		}
+
+		if workspaceMembers.Next == "" {
+			break
+		}
+		options.Page = optional.NewInt32(workspaceMembers.Page + 1)
+	}
+
+	users := make([]bitbucket.Account, 0, displayNames.Len())
+	for _, item := range displayNames.List() {
+		displayName := item.(string)
+		uuid, ok := memberUUIDs[displayName]
+		if !ok {
+			return nil, fmt.Errorf("user not found in workspace %q: %s", workspace, displayName)
+		}
+
+		users = append(users, bitbucket.Account{Uuid: uuid})
+	}
+
+	return users, nil
+}
+
 func resourceBranchRestrictionsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(Clients).genClient
 	brApi := c.ApiClient.BranchRestrictionsApi
-	branchRestriction := createBranchRestriction(d)
 
 	repo := d.Get("repository").(string)
 	workspace := d.Get("owner").(string)
+	users, err := branchRestrictionUsers(c, workspace, d.Get("users").(*schema.Set))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	branchRestriction := createBranchRestriction(d, users)
+
 	branchRestrictionReq, res, err := brApi.RepositoriesWorkspaceRepoSlugBranchRestrictionsPost(c.AuthContext, *branchRestriction, repo, workspace)
 	if err := handleClientError(res, err); err != nil {
 		return diag.FromErr(err)
@@ -225,7 +261,7 @@ func resourceBranchRestrictionsRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("kind", brRes.Kind)
 	d.Set("pattern", brRes.Pattern)
 	d.Set("value", brRes.Value)
-	d.Set("users", brRes.Users)
+	d.Set("users", flattenBranchRestrictionUsers(brRes.Users))
 	d.Set("groups", brRes.Groups)
 	d.Set("branch_type", brRes.BranchType)
 	d.Set("branch_match_kind", brRes.BranchMatchKind)
@@ -233,10 +269,24 @@ func resourceBranchRestrictionsRead(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
+func flattenBranchRestrictionUsers(users []bitbucket.Account) []string {
+	displayNames := make([]string, 0, len(users))
+	for _, user := range users {
+		displayNames = append(displayNames, user.DisplayName)
+	}
+
+	return displayNames
+}
+
 func resourceBranchRestrictionsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(Clients).genClient
 	brApi := c.ApiClient.BranchRestrictionsApi
-	branchRestriction := createBranchRestriction(d)
+	workspace := d.Get("owner").(string)
+	users, err := branchRestrictionUsers(c, workspace, d.Get("users").(*schema.Set))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	branchRestriction := createBranchRestriction(d, users)
 
 	_, res, err := brApi.RepositoriesWorkspaceRepoSlugBranchRestrictionsIdPut(c.AuthContext,
 		*branchRestriction, url.PathEscape(d.Id()),

--- a/bitbucket/resource_branch_restriction_test.go
+++ b/bitbucket/resource_branch_restriction_test.go
@@ -7,10 +7,30 @@ import (
 	"os"
 	"testing"
 
+	bitbucket "github.com/DrFaust92/bitbucket-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func TestFlattenBranchRestrictionUsers(t *testing.T) {
+	users := []bitbucket.Account{
+		{DisplayName: "Jane Doe", Username: "jane"},
+		{DisplayName: "John Smith", Username: "john"},
+	}
+
+	got := flattenBranchRestrictionUsers(users)
+	want := []string{"Jane Doe", "John Smith"}
+
+	if len(got) != len(want) {
+		t.Fatalf("flattenBranchRestrictionUsers() returned %d users, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("flattenBranchRestrictionUsers()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
 
 func TestAccBitbucketBranchRestriction_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-test")

--- a/docs/resources/branch_restriction.md
+++ b/docs/resources/branch_restriction.md
@@ -12,8 +12,8 @@ Provides a Bitbucket branch restriction resource.
 
 This allows you for setting up branch restrictions for your repository.
 
-* OAuth2 Scopes: `repository:admin`
-* API token permissions: `read:repository:bitbucket` and `admin:repository:bitbucket`
+* OAuth2 Scopes: `repository:admin`; using `users` additionally requires `account`
+* API token permissions: `read:repository:bitbucket` and `admin:repository:bitbucket`; using `users` additionally requires `read:workspace:bitbucket`
 
 ## Example Usage
 
@@ -25,7 +25,7 @@ resource "bitbucket_branch_restriction" "master" {
   kind = "push"
   pattern = "master"
 
-  users = [ "my-bitbucket-username" ]
+  users = [ "My Display Name" ]
 
   groups {
     slug = "my-group"
@@ -45,7 +45,7 @@ The following arguments are supported:
 * `branch_match_kind` - (Optional) Indicates how the restriction is matched against a branch. The default is `glob`. Valid values: `branching_model`, `glob`.
 * `branch_type` - (Optional) Apply the restriction to branches of this type. Active when `branch_match_kind` is `branching_model`. The branch type will be calculated using the branching model configured for the repository. Valid values: `feature`, `bugfix`, `release`, `hotfix`, `development`, `production`.
 * `pattern` - (Optional) Apply the restriction to branches that match this pattern. Active when `branch_match_kind` is `glob`. Will be empty when `branch_match_kind` is `branching_model`.
-* `users` - (Optional) A list of users to use.
+* `users` - (Optional) A list of user display names to use. On create and update, each display name is mapped to its workspace member UUID. When the restriction is refreshed or imported, each user account returned by Bitbucket is stored in state using its `display_name`.
 * `groups` - (Optional) A list of groups to use.
 * `value` - (Optional) A value applied to the restriction kind. Currently only applicable to `require_passing_builds_to_merge`, `require_default_reviewer_approvals_to_merge` and `require_approvals_to_merge`.
 


### PR DESCRIPTION
## Summary

Fix branch restriction user handling so Terraform state and Bitbucket API requests use the correct representations.

## Problem

Bitbucket returns complete account objects when reading branch restrictions, while Terraform expects users to be a set of strings:

`[ERROR] setting state: users.0: '' expected type 'string', got unconvertible type 'bitbucket.Account', value: '{0001-01-01 00:00:00 +0000 UTC <display-name> <links> {<user-uuid>} user}'`

After extracting display names during reads, updates also need to map those names back to UUIDs. Otherwise, Bitbucket treats a display name as a username and returns 404 user not found.

## Changes

- Store user display names in Terraform state when reading branch restrictions.
- Resolve display names to workspace member UUIDs before creating or updating restrictions.
- Support paginated workspace member responses.
- Document the additional workspace-read permissions required when using users.
- Add unit coverage for flattening Bitbucket accounts.

## Testing

`go test ./bitbucket`