### PR TITLE
Add retries on rate limit

### DIFF
--- a/bitbucket/provider.go
+++ b/bitbucket/provider.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/DrFaust92/bitbucket-go-client"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	oauth2bitbucket "golang.org/x/oauth2/bitbucket"
 	oauth2clientcreds "golang.org/x/oauth2/clientcredentials"
@@ -117,11 +118,27 @@ func Provider() *schema.Provider {
 	}
 }
 
+func newHTTPClient() *http.Client {
+	client := retryablehttp.NewClient()
+	client.Logger = nil
+	client.RetryMax = 10
+	client.CheckRetry = func(ctx context.Context, response *http.Response, err error) (bool, error) {
+		if err != nil {
+			return false, err
+		}
+		return response.StatusCode == http.StatusTooManyRequests, nil
+	}
+	client.Backoff = retryablehttp.RateLimitLinearJitterBackoff
+	client.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	return client.StandardClient()
+}
+
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	authCtx := context.Background()
 
+	httpClient := newHTTPClient()
 	client := &Client{
-		HTTPClient: &http.Client{},
+		HTTPClient: httpClient,
 	}
 
 	if username, ok := d.GetOk("username"); ok {
@@ -168,6 +185,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	conf := bitbucket.NewConfiguration()
+	conf.HTTPClient = httpClient
 	apiClient := ProviderConfig{
 		ApiClient:   bitbucket.NewAPIClient(conf),
 		AuthContext: authCtx,

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/DrFaust92/bitbucket-go-client v0.11.0
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/antihax/optional v1.0.0
+	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/satori/go.uuid v1.2.0
 	golang.org/x/crypto v0.54.0
@@ -24,7 +25,6 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/hc-install v0.9.4 // indirect


### PR DESCRIPTION
## Problem

When running terraform plan or apply on terraform environments with a large number of resources there are large bursts of requests which trigger 429 rate limits. This means that parallelism has to be set to 1 which makes commands slow.

```
│ Error: API Error: 429 2.0/repositories/...
```

This is not the hourly limit, when running just terraform plan it will always fail but when running commands with parallelism 1 or this fix it completes successfully multiple times in as row. 

## Solution

Retry request when there is a 429 response

### Changes

- bitbucket/provider.go - Added one shared retrying HTTP client for both Bitbucket API clients (only on 429 responses, uses jittered backoff, allows up to 10 retries)

## Testing

- All unit tests pass (`go test ./...`)
- Verified locally: `terraform plan` (Command completes in around half the time compared to running terraform plan -parallelism=1)

---
